### PR TITLE
feat(plugins): add Kubernetes plugin foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test-unit = "scripts.test_scripts:unit"
 [tool.poetry.plugins."system_operations_manager.plugins"]
 core = "system_operations_manager.plugins.core:CorePlugin"
 kong = "system_operations_manager.plugins.kong:KongPlugin"
+kubernetes = "system_operations_manager.plugins.kubernetes:KubernetesPlugin"
 
 [tool.poetry.dependencies]
 python = ">=3.14.3,<4.0"

--- a/src/system_operations_manager/integrations/kubernetes/__init__.py
+++ b/src/system_operations_manager/integrations/kubernetes/__init__.py
@@ -1,0 +1,33 @@
+"""Kubernetes integration - API client and configuration models."""
+
+from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+from system_operations_manager.integrations.kubernetes.config import (
+    ClusterConfig,
+    KubernetesAuthConfig,
+    KubernetesDefaultsConfig,
+    KubernetesPluginConfig,
+)
+from system_operations_manager.integrations.kubernetes.exceptions import (
+    KubernetesAuthError,
+    KubernetesConflictError,
+    KubernetesConnectionError,
+    KubernetesError,
+    KubernetesNotFoundError,
+    KubernetesTimeoutError,
+    KubernetesValidationError,
+)
+
+__all__ = [
+    "ClusterConfig",
+    "KubernetesAuthConfig",
+    "KubernetesAuthError",
+    "KubernetesClient",
+    "KubernetesConflictError",
+    "KubernetesConnectionError",
+    "KubernetesDefaultsConfig",
+    "KubernetesError",
+    "KubernetesNotFoundError",
+    "KubernetesPluginConfig",
+    "KubernetesTimeoutError",
+    "KubernetesValidationError",
+]

--- a/src/system_operations_manager/integrations/kubernetes/client.py
+++ b/src/system_operations_manager/integrations/kubernetes/client.py
@@ -1,0 +1,440 @@
+"""Kubernetes API client wrapper.
+
+Provides a multi-cluster client that wraps the official kubernetes Python client
+with context switching, lazy API group initialization, retry logic, and consistent
+error translation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from system_operations_manager.integrations.kubernetes.exceptions import (
+    KubernetesAuthError,
+    KubernetesConflictError,
+    KubernetesConnectionError,
+    KubernetesError,
+    KubernetesNotFoundError,
+    KubernetesValidationError,
+)
+
+if TYPE_CHECKING:
+    from kubernetes.client import (
+        AppsV1Api,
+        BatchV1Api,
+        CoreV1Api,
+        NetworkingV1Api,
+        RbacAuthorizationV1Api,
+        StorageV1Api,
+        VersionApi,
+    )
+
+    from system_operations_manager.integrations.kubernetes.config import (
+        KubernetesPluginConfig,
+    )
+
+logger = structlog.get_logger()
+
+
+class KubernetesClient:
+    """Multi-cluster Kubernetes API client.
+
+    Wraps the official kubernetes Python client with:
+    - Multi-cluster context management via kubeconfig
+    - Lazy API group initialization
+    - Automatic retry with tenacity for transient errors
+    - Consistent error translation to custom exceptions
+    - Context manager support
+
+    Example:
+        ```python
+        from system_operations_manager.integrations.kubernetes import KubernetesClient
+        from system_operations_manager.integrations.kubernetes.config import (
+            KubernetesPluginConfig,
+        )
+
+        config = KubernetesPluginConfig.from_env()
+        with KubernetesClient(config) as client:
+            nodes = client.core_v1.list_node()
+            print(f"Cluster has {len(nodes.items)} nodes")
+        ```
+    """
+
+    def __init__(self, plugin_config: KubernetesPluginConfig) -> None:
+        """Initialize Kubernetes client from plugin config.
+
+        Loads kubeconfig and sets the active context. If no clusters are
+        configured, falls back to default kubeconfig auto-detection
+        (matching the existing KubernetesService behavior).
+
+        Args:
+            plugin_config: Complete plugin configuration.
+        """
+        self._config = plugin_config
+        self._retries = plugin_config.defaults.retry_attempts
+        self._current_context: str | None = None
+
+        # Lazy-loaded API group instances
+        self._core_v1: CoreV1Api | None = None
+        self._apps_v1: AppsV1Api | None = None
+        self._batch_v1: BatchV1Api | None = None
+        self._networking_v1: NetworkingV1Api | None = None
+        self._rbac_v1: RbacAuthorizationV1Api | None = None
+        self._storage_v1: StorageV1Api | None = None
+        self._version_api: VersionApi | None = None
+
+        # Load kubeconfig
+        self._load_config()
+
+        logger.info(
+            "Kubernetes client initialized",
+            context=self._current_context,
+            default_namespace=plugin_config.get_active_namespace(),
+        )
+
+    def _load_config(self) -> None:
+        """Load Kubernetes configuration from kubeconfig or in-cluster."""
+        from kubernetes import config
+        from kubernetes.config import ConfigException
+
+        active_context = self._config.get_active_context()
+
+        try:
+            # Determine kubeconfig path
+            kubeconfig_path = None
+            if self._config.active_cluster and self._config.active_cluster in self._config.clusters:
+                cluster_cfg = self._config.clusters[self._config.active_cluster]
+                kubeconfig_path = cluster_cfg.kubeconfig
+
+            config.load_kube_config(
+                config_file=kubeconfig_path,
+                context=active_context,
+            )
+            self._current_context = active_context
+            logger.debug(
+                "loaded_kubeconfig",
+                context=active_context,
+                kubeconfig=kubeconfig_path,
+            )
+        except ConfigException:
+            try:
+                config.load_incluster_config()
+                self._current_context = "in-cluster"
+                logger.debug("loaded_incluster_config")
+            except ConfigException as e:
+                raise KubernetesConnectionError(
+                    message="Cannot load Kubernetes configuration. "
+                    "Ensure kubeconfig exists or running inside a cluster.",
+                    original_error=e,
+                ) from e
+
+        # Reset cached API instances on config change
+        self._invalidate_api_cache()
+
+    def _invalidate_api_cache(self) -> None:
+        """Clear cached API group instances."""
+        self._core_v1 = None
+        self._apps_v1 = None
+        self._batch_v1 = None
+        self._networking_v1 = None
+        self._rbac_v1 = None
+        self._storage_v1 = None
+        self._version_api = None
+
+    # =========================================================================
+    # Lazy API Group Accessors
+    # =========================================================================
+
+    @property
+    def core_v1(self) -> CoreV1Api:
+        """Get CoreV1Api instance (pods, services, namespaces, secrets, configmaps, etc.)."""
+        if self._core_v1 is None:
+            from kubernetes.client import CoreV1Api
+
+            self._core_v1 = CoreV1Api()
+        return self._core_v1
+
+    @property
+    def apps_v1(self) -> AppsV1Api:
+        """Get AppsV1Api instance (deployments, statefulsets, daemonsets, replicasets)."""
+        if self._apps_v1 is None:
+            from kubernetes.client import AppsV1Api
+
+            self._apps_v1 = AppsV1Api()
+        return self._apps_v1
+
+    @property
+    def batch_v1(self) -> BatchV1Api:
+        """Get BatchV1Api instance (jobs, cronjobs)."""
+        if self._batch_v1 is None:
+            from kubernetes.client import BatchV1Api
+
+            self._batch_v1 = BatchV1Api()
+        return self._batch_v1
+
+    @property
+    def networking_v1(self) -> NetworkingV1Api:
+        """Get NetworkingV1Api instance (ingresses, networkpolicies)."""
+        if self._networking_v1 is None:
+            from kubernetes.client import NetworkingV1Api
+
+            self._networking_v1 = NetworkingV1Api()
+        return self._networking_v1
+
+    @property
+    def rbac_v1(self) -> RbacAuthorizationV1Api:
+        """Get RbacAuthorizationV1Api instance (roles, clusterroles, bindings)."""
+        if self._rbac_v1 is None:
+            from kubernetes.client import RbacAuthorizationV1Api
+
+            self._rbac_v1 = RbacAuthorizationV1Api()
+        return self._rbac_v1
+
+    @property
+    def storage_v1(self) -> StorageV1Api:
+        """Get StorageV1Api instance (storageclasses, pvs, pvcs)."""
+        if self._storage_v1 is None:
+            from kubernetes.client import StorageV1Api
+
+            self._storage_v1 = StorageV1Api()
+        return self._storage_v1
+
+    @property
+    def version_api(self) -> VersionApi:
+        """Get VersionApi instance for cluster version info."""
+        if self._version_api is None:
+            from kubernetes.client import VersionApi
+
+            self._version_api = VersionApi()
+        return self._version_api
+
+    # =========================================================================
+    # Context Management
+    # =========================================================================
+
+    def switch_context(self, context_name: str) -> None:
+        """Switch to a different Kubernetes context.
+
+        Args:
+            context_name: The kubeconfig context name or a named cluster
+                from the plugin config.
+
+        Raises:
+            KubernetesConnectionError: If the context cannot be loaded.
+        """
+        from kubernetes import config
+        from kubernetes.config import ConfigException
+
+        # Check if it's a named cluster in our config
+        kubeconfig_path = None
+        if context_name in self._config.clusters:
+            cluster_cfg = self._config.clusters[context_name]
+            context_name = cluster_cfg.context
+            kubeconfig_path = cluster_cfg.kubeconfig
+
+        try:
+            config.load_kube_config(
+                config_file=kubeconfig_path,
+                context=context_name,
+            )
+            self._current_context = context_name
+            self._invalidate_api_cache()
+            logger.info("switched_context", context=context_name)
+        except ConfigException as e:
+            raise KubernetesConnectionError(
+                message=f"Failed to switch to context '{context_name}'",
+                original_error=e,
+            ) from e
+
+    def get_current_context(self) -> str:
+        """Get the current active context name.
+
+        Returns:
+            The current context name, or 'in-cluster' if running inside a pod.
+        """
+        return self._current_context or "unknown"
+
+    def list_contexts(self) -> list[dict[str, Any]]:
+        """List all available kubeconfig contexts.
+
+        Returns:
+            List of context dictionaries with 'name', 'cluster', and 'namespace' keys.
+        """
+        from kubernetes import config
+
+        try:
+            contexts, active = config.list_kube_config_contexts()
+        except Exception:
+            return []
+
+        result = []
+        for ctx in contexts:
+            ctx_info = ctx.get("context", {})
+            result.append(
+                {
+                    "name": ctx.get("name", ""),
+                    "cluster": ctx_info.get("cluster", ""),
+                    "namespace": ctx_info.get("namespace", "default"),
+                    "active": ctx.get("name") == active.get("name") if active else False,
+                }
+            )
+        return result
+
+    # =========================================================================
+    # Error Translation
+    # =========================================================================
+
+    @staticmethod
+    def translate_api_exception(
+        e: Exception,
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        namespace: str | None = None,
+    ) -> KubernetesError:
+        """Translate a kubernetes ApiException to a custom exception.
+
+        Args:
+            e: The original ApiException.
+            resource_type: Type of resource being operated on.
+            resource_name: Name of the resource.
+            namespace: Namespace of the resource.
+
+        Returns:
+            An appropriate KubernetesError subclass.
+        """
+        from kubernetes.client import ApiException
+
+        if not isinstance(e, ApiException):
+            return KubernetesError(
+                message=str(e),
+                resource_type=resource_type,
+                resource_name=resource_name,
+                namespace=namespace,
+            )
+
+        status = e.status
+
+        if status in (401, 403):
+            return KubernetesAuthError(
+                message=e.reason or "Authentication/authorization failed",
+                status_code=status,
+                reason=e.reason,
+            )
+
+        if status == 404:
+            return KubernetesNotFoundError(
+                resource_type=resource_type,
+                resource_name=resource_name,
+                namespace=namespace,
+            )
+
+        if status == 409:
+            return KubernetesConflictError(
+                resource_type=resource_type,
+                resource_name=resource_name,
+                namespace=namespace,
+            )
+
+        if status in (400, 422):
+            return KubernetesValidationError(
+                message=e.reason or "Validation failed",
+                status_code=status,
+            )
+
+        return KubernetesError(
+            message=e.reason or f"Kubernetes API error: {status}",
+            status_code=status,
+            resource_type=resource_type,
+            resource_name=resource_name,
+            namespace=namespace,
+        )
+
+    # =========================================================================
+    # Retry Decorator
+    # =========================================================================
+
+    def make_retry_decorator(self) -> Any:
+        """Create a retry decorator for transient connection errors.
+
+        Returns:
+            A tenacity retry decorator configured with exponential backoff.
+        """
+        return retry(
+            retry=retry_if_exception_type(KubernetesConnectionError),
+            stop=stop_after_attempt(self._retries),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            reraise=True,
+        )
+
+    # =========================================================================
+    # Connection Check
+    # =========================================================================
+
+    def check_connection(self) -> bool:
+        """Check if connection to the Kubernetes API server is working.
+
+        Returns:
+            True if connection is successful, False otherwise.
+        """
+        try:
+            self.version_api.get_code()
+            return True
+        except Exception:
+            return False
+
+    def get_cluster_version(self) -> str:
+        """Get the Kubernetes cluster version string.
+
+        Returns:
+            Kubernetes version (e.g., "v1.28.3").
+
+        Raises:
+            KubernetesConnectionError: If the cluster is unreachable.
+        """
+        try:
+            version_info = self.version_api.get_code()
+            return f"v{version_info.major}.{version_info.minor}"
+        except Exception as e:
+            raise KubernetesConnectionError(
+                message="Failed to get cluster version",
+                original_error=e,
+            ) from e
+
+    # =========================================================================
+    # Properties
+    # =========================================================================
+
+    @property
+    def default_namespace(self) -> str:
+        """Get the default namespace from config."""
+        return self._config.get_active_namespace()
+
+    @property
+    def timeout(self) -> int:
+        """Get the configured timeout."""
+        return self._config.get_active_timeout()
+
+    # =========================================================================
+    # Lifecycle
+    # =========================================================================
+
+    def close(self) -> None:
+        """Close the client and release resources."""
+        self._invalidate_api_cache()
+        logger.debug("Kubernetes client closed")
+
+    def __enter__(self) -> KubernetesClient:
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        self.close()

--- a/src/system_operations_manager/integrations/kubernetes/config.py
+++ b/src/system_operations_manager/integrations/kubernetes/config.py
@@ -1,0 +1,216 @@
+"""Kubernetes integration configuration models."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class ClusterConfig(BaseModel):
+    """Configuration for a single Kubernetes cluster."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    context: str = ""
+    kubeconfig: str = "~/.kube/config"
+    namespace: str = "default"
+    timeout: int = 300
+
+    @field_validator("timeout")
+    @classmethod
+    def validate_timeout(cls, v: int) -> int:
+        """Validate timeout is positive."""
+        if v <= 0:
+            raise ValueError("timeout must be positive")
+        return v
+
+    @field_validator("kubeconfig")
+    @classmethod
+    def validate_kubeconfig(cls, v: str) -> str:
+        """Expand ~ in kubeconfig path."""
+        return str(Path(v).expanduser())
+
+
+class KubernetesAuthConfig(BaseModel):
+    """Kubernetes authentication configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["kubeconfig", "token", "service_account", "certificate"] = "kubeconfig"
+    token: str | None = None
+    cert_path: str | None = None
+    key_path: str | None = None
+    ca_path: str | None = None
+
+    @field_validator("type")
+    @classmethod
+    def validate_auth_type(cls, v: str) -> str:
+        """Validate authentication type."""
+        valid_types = {"kubeconfig", "token", "service_account", "certificate"}
+        if v not in valid_types:
+            raise ValueError(f"auth type must be one of: {', '.join(sorted(valid_types))}")
+        return v
+
+
+class KubernetesDefaultsConfig(BaseModel):
+    """Default settings for Kubernetes operations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timeout: int = 300
+    retry_attempts: int = 3
+    dry_run_strategy: Literal["none", "client", "server"] = "none"
+
+    @field_validator("timeout")
+    @classmethod
+    def validate_timeout(cls, v: int) -> int:
+        """Validate timeout is positive."""
+        if v <= 0:
+            raise ValueError("timeout must be positive")
+        return v
+
+    @field_validator("retry_attempts")
+    @classmethod
+    def validate_retry_attempts(cls, v: int) -> int:
+        """Validate retry_attempts is non-negative."""
+        if v < 0:
+            raise ValueError("retry_attempts must be non-negative")
+        return v
+
+
+class KubernetesPluginConfig(BaseModel):
+    """Complete Kubernetes plugin configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    clusters: dict[str, ClusterConfig] = {}
+    active_cluster: str | None = None
+    defaults: KubernetesDefaultsConfig = KubernetesDefaultsConfig()
+    auth: KubernetesAuthConfig = KubernetesAuthConfig()
+    output_format: Literal["table", "json", "yaml"] = "table"
+
+    @field_validator("output_format")
+    @classmethod
+    def validate_output_format(cls, v: str) -> str:
+        """Validate output format."""
+        valid_formats = {"table", "json", "yaml"}
+        if v not in valid_formats:
+            raise ValueError(f"output_format must be one of: {', '.join(sorted(valid_formats))}")
+        return v
+
+    @classmethod
+    def from_env(cls, base_config: dict[str, Any] | None = None) -> KubernetesPluginConfig:
+        """Create configuration with environment variable overrides.
+
+        Environment variables take precedence over base_config values.
+
+        Supported environment variables:
+            OPS_K8S_CONTEXT: Override active Kubernetes context
+            OPS_K8S_NAMESPACE: Override default namespace
+            OPS_K8S_KUBECONFIG: Override kubeconfig path
+            OPS_K8S_TOKEN: Bearer token for authentication
+            OPS_K8S_TIMEOUT: Default timeout in seconds
+            OPS_K8S_OUTPUT: Output format (table, json, yaml)
+            OPS_K8S_DRY_RUN: Dry run strategy (none, client, server)
+        """
+        config_dict = base_config.copy() if base_config else {}
+
+        # Ensure nested dicts exist
+        if "defaults" not in config_dict:
+            config_dict["defaults"] = {}
+        if "auth" not in config_dict:
+            config_dict["auth"] = {}
+        if "clusters" not in config_dict:
+            config_dict["clusters"] = {}
+
+        # Kubeconfig path override
+        if kubeconfig := os.environ.get("OPS_K8S_KUBECONFIG"):
+            # Apply to default cluster or all clusters without explicit kubeconfig
+            config_dict.setdefault("_kubeconfig_override", kubeconfig)
+
+        # Context override -> set as active_cluster
+        if context := os.environ.get("OPS_K8S_CONTEXT"):
+            config_dict["active_cluster"] = context
+
+        # Namespace override -> apply to default cluster config
+        if namespace := os.environ.get("OPS_K8S_NAMESPACE"):
+            config_dict.setdefault("_namespace_override", namespace)
+
+        # Token auth override
+        if token := os.environ.get("OPS_K8S_TOKEN"):
+            config_dict["auth"]["token"] = token
+            if config_dict["auth"].get("type", "kubeconfig") == "kubeconfig":
+                config_dict["auth"]["type"] = "token"
+
+        # Timeout override
+        if timeout := os.environ.get("OPS_K8S_TIMEOUT"):
+            config_dict["defaults"]["timeout"] = int(timeout)
+
+        # Output format override
+        if output_format := os.environ.get("OPS_K8S_OUTPUT"):
+            config_dict["output_format"] = output_format
+
+        # Dry run override
+        if dry_run := os.environ.get("OPS_K8S_DRY_RUN"):
+            config_dict["defaults"]["dry_run_strategy"] = dry_run
+
+        # Extract internal override keys before validation
+        kubeconfig_override = config_dict.pop("_kubeconfig_override", None)
+        namespace_override = config_dict.pop("_namespace_override", None)
+
+        instance = cls.model_validate(config_dict)
+
+        # Apply overrides to the resolved config
+        if kubeconfig_override:
+            for cluster_cfg in instance.clusters.values():
+                cluster_cfg.kubeconfig = str(Path(kubeconfig_override).expanduser())
+
+        if namespace_override:
+            for cluster_cfg in instance.clusters.values():
+                cluster_cfg.namespace = namespace_override
+
+        return instance
+
+    def get_active_context(self) -> str | None:
+        """Get the active cluster context name.
+
+        Returns the active_cluster if set, or the context from the first
+        configured cluster, or None if no clusters are configured.
+        """
+        if self.active_cluster:
+            # If active_cluster matches a named cluster, return its context
+            if cluster := self.clusters.get(self.active_cluster):
+                return cluster.context
+            # Otherwise treat it as a raw context name
+            return self.active_cluster
+        # Fall back to first cluster's context
+        if self.clusters:
+            first = next(iter(self.clusters.values()))
+            return first.context
+        return None
+
+    def get_active_namespace(self) -> str:
+        """Get the default namespace for the active cluster.
+
+        Returns the namespace from the active cluster config,
+        or 'default' if no cluster is configured.
+        """
+        if self.active_cluster and self.active_cluster in self.clusters:
+            return self.clusters[self.active_cluster].namespace
+        if self.clusters:
+            first = next(iter(self.clusters.values()))
+            return first.namespace
+        return "default"
+
+    def get_active_timeout(self) -> int:
+        """Get the timeout for the active cluster.
+
+        Returns the timeout from the active cluster config,
+        or the default timeout.
+        """
+        if self.active_cluster and self.active_cluster in self.clusters:
+            return self.clusters[self.active_cluster].timeout
+        return self.defaults.timeout

--- a/src/system_operations_manager/integrations/kubernetes/exceptions.py
+++ b/src/system_operations_manager/integrations/kubernetes/exceptions.py
@@ -1,0 +1,214 @@
+"""Kubernetes integration custom exceptions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class KubernetesError(Exception):
+    """Base exception for Kubernetes operations.
+
+    Attributes:
+        message: Human-readable error message.
+        status_code: HTTP status code from Kubernetes API (if applicable).
+        resource_type: Type of resource involved (e.g., "Pod", "Deployment").
+        resource_name: Name of the resource involved.
+        namespace: Namespace of the resource (if applicable).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        namespace: str | None = None,
+    ) -> None:
+        """Initialize KubernetesError.
+
+        Args:
+            message: Human-readable error message.
+            status_code: HTTP status code from Kubernetes API.
+            resource_type: Type of resource involved.
+            resource_name: Name of the resource involved.
+            namespace: Namespace of the resource.
+        """
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.resource_type = resource_type
+        self.resource_name = resource_name
+        self.namespace = namespace
+
+    def __str__(self) -> str:
+        """Return string representation of the error."""
+        parts = [self.message]
+        if self.status_code:
+            parts.append(f"(status: {self.status_code})")
+        if self.resource_type and self.resource_name:
+            loc = f"[{self.resource_type}/{self.resource_name}"
+            if self.namespace:
+                loc += f" in {self.namespace}"
+            loc += "]"
+            parts.append(loc)
+        return " ".join(parts)
+
+
+class KubernetesConnectionError(KubernetesError):
+    """Exception raised when connection to a Kubernetes cluster fails.
+
+    This includes network errors, kubeconfig issues, and unreachable API servers.
+    """
+
+    def __init__(
+        self,
+        message: str = "Failed to connect to Kubernetes cluster",
+        original_error: Exception | None = None,
+    ) -> None:
+        """Initialize KubernetesConnectionError.
+
+        Args:
+            message: Human-readable error message.
+            original_error: The original exception that caused this error.
+        """
+        super().__init__(message=message)
+        self.original_error = original_error
+
+
+class KubernetesAuthError(KubernetesError):
+    """Exception raised when authentication or authorization fails.
+
+    This includes invalid tokens, expired certificates, and RBAC denials (401/403).
+    """
+
+    def __init__(
+        self,
+        message: str = "Kubernetes authentication/authorization failed",
+        status_code: int | None = 401,
+        reason: str | None = None,
+    ) -> None:
+        """Initialize KubernetesAuthError.
+
+        Args:
+            message: Human-readable error message.
+            status_code: HTTP status code (usually 401 or 403).
+            reason: Kubernetes API reason string.
+        """
+        super().__init__(message=message, status_code=status_code)
+        self.reason = reason
+
+
+class KubernetesNotFoundError(KubernetesError):
+    """Exception raised when a requested Kubernetes resource is not found.
+
+    This is typically a 404 response from the Kubernetes API.
+    """
+
+    def __init__(
+        self,
+        message: str = "Kubernetes resource not found",
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        namespace: str | None = None,
+    ) -> None:
+        """Initialize KubernetesNotFoundError.
+
+        Args:
+            message: Human-readable error message.
+            resource_type: Type of resource (e.g., "Pod", "Deployment").
+            resource_name: Name of the resource.
+            namespace: Namespace of the resource.
+        """
+        if resource_type and resource_name:
+            message = f"{resource_type} '{resource_name}' not found"
+            if namespace:
+                message += f" in namespace '{namespace}'"
+        super().__init__(
+            message=message,
+            status_code=404,
+            resource_type=resource_type,
+            resource_name=resource_name,
+            namespace=namespace,
+        )
+
+
+class KubernetesValidationError(KubernetesError):
+    """Exception raised when Kubernetes API rejects invalid resource specs.
+
+    This is typically a 400/422 response indicating schema validation failure.
+    """
+
+    def __init__(
+        self,
+        message: str = "Invalid resource specification",
+        validation_errors: dict[str, Any] | None = None,
+        status_code: int | None = 422,
+    ) -> None:
+        """Initialize KubernetesValidationError.
+
+        Args:
+            message: Human-readable error message.
+            validation_errors: Specific field validation errors.
+            status_code: HTTP status code (usually 400 or 422).
+        """
+        super().__init__(message=message, status_code=status_code)
+        self.validation_errors = validation_errors or {}
+
+
+class KubernetesConflictError(KubernetesError):
+    """Exception raised when a resource conflict occurs.
+
+    This is typically a 409 response indicating the resource already exists
+    or has been modified by another client.
+    """
+
+    def __init__(
+        self,
+        message: str = "Resource conflict",
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        namespace: str | None = None,
+    ) -> None:
+        """Initialize KubernetesConflictError.
+
+        Args:
+            message: Human-readable error message.
+            resource_type: Type of resource.
+            resource_name: Name of the resource.
+            namespace: Namespace of the resource.
+        """
+        if resource_type and resource_name:
+            message = f"{resource_type} '{resource_name}' already exists"
+            if namespace:
+                message += f" in namespace '{namespace}'"
+        super().__init__(
+            message=message,
+            status_code=409,
+            resource_type=resource_type,
+            resource_name=resource_name,
+            namespace=namespace,
+        )
+
+
+class KubernetesTimeoutError(KubernetesError):
+    """Exception raised when a Kubernetes operation times out.
+
+    This includes watch timeouts, long-running operation timeouts,
+    and API request timeouts.
+    """
+
+    def __init__(
+        self,
+        message: str = "Kubernetes operation timed out",
+        timeout_seconds: int | None = None,
+    ) -> None:
+        """Initialize KubernetesTimeoutError.
+
+        Args:
+            message: Human-readable error message.
+            timeout_seconds: The timeout value that was exceeded.
+        """
+        if timeout_seconds:
+            message = f"{message} (after {timeout_seconds}s)"
+        super().__init__(message=message)
+        self.timeout_seconds = timeout_seconds

--- a/src/system_operations_manager/integrations/kubernetes/models/__init__.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/__init__.py
@@ -1,0 +1,77 @@
+"""Kubernetes resource display models."""
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    OwnerReference,
+)
+from system_operations_manager.integrations.kubernetes.models.cluster import (
+    EventSummary,
+    NamespaceSummary,
+    NodeSummary,
+)
+from system_operations_manager.integrations.kubernetes.models.configuration import (
+    ConfigMapSummary,
+    SecretSummary,
+)
+from system_operations_manager.integrations.kubernetes.models.jobs import (
+    CronJobSummary,
+    JobSummary,
+)
+from system_operations_manager.integrations.kubernetes.models.networking import (
+    IngressRule,
+    IngressSummary,
+    NetworkPolicySummary,
+    ServicePort,
+    ServiceSummary,
+)
+from system_operations_manager.integrations.kubernetes.models.rbac import (
+    PolicyRule,
+    RoleBindingSummary,
+    RoleSummary,
+    ServiceAccountSummary,
+    Subject,
+)
+from system_operations_manager.integrations.kubernetes.models.storage import (
+    PersistentVolumeClaimSummary,
+    PersistentVolumeSummary,
+    StorageClassSummary,
+)
+from system_operations_manager.integrations.kubernetes.models.workloads import (
+    ContainerStatus,
+    DaemonSetSummary,
+    DeploymentSummary,
+    PodSummary,
+    ReplicaSetSummary,
+    StatefulSetSummary,
+)
+
+__all__ = [
+    "ConfigMapSummary",
+    "ContainerStatus",
+    "CronJobSummary",
+    "DaemonSetSummary",
+    "DeploymentSummary",
+    "EventSummary",
+    "IngressRule",
+    "IngressSummary",
+    "JobSummary",
+    "K8sEntityBase",
+    "NamespaceSummary",
+    "NetworkPolicySummary",
+    "NodeSummary",
+    "OwnerReference",
+    "PersistentVolumeClaimSummary",
+    "PersistentVolumeSummary",
+    "PodSummary",
+    "PolicyRule",
+    "ReplicaSetSummary",
+    "RoleBindingSummary",
+    "RoleSummary",
+    "SecretSummary",
+    "ServiceAccountSummary",
+    "ServicePort",
+    "ServiceSummary",
+    "StatefulSetSummary",
+    "StorageClassSummary",
+    "Subject",
+]

--- a/src/system_operations_manager/integrations/kubernetes/models/base.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/base.py
@@ -1,0 +1,102 @@
+"""Base models for Kubernetes resource display."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class K8sEntityBase(BaseModel):
+    """Base class for all Kubernetes display models."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        str_strip_whitespace=True,
+    )
+
+    name: str = Field(description="Resource name")
+    namespace: str | None = Field(default=None, description="Resource namespace")
+    uid: str | None = Field(default=None, description="Kubernetes UID")
+    creation_timestamp: str | None = Field(default=None, description="Creation time")
+    labels: dict[str, str] | None = Field(default=None, description="Resource labels")
+    annotations: dict[str, str] | None = Field(default=None, description="Resource annotations")
+
+    _entity_name: ClassVar[str] = "entity"
+
+    @property
+    def age(self) -> str:
+        """Human-readable age string."""
+        if not self.creation_timestamp:
+            return "Unknown"
+        try:
+            created = datetime.fromisoformat(self.creation_timestamp.replace("Z", "+00:00"))
+            delta = datetime.now(UTC) - created
+            days = delta.days
+            hours, remainder = divmod(delta.seconds, 3600)
+            minutes = remainder // 60
+            if days > 0:
+                return f"{days}d"
+            if hours > 0:
+                return f"{hours}h"
+            return f"{minutes}m"
+        except ValueError, TypeError:
+            return "Unknown"
+
+
+class OwnerReference(BaseModel):
+    """Kubernetes owner reference."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    api_version: str | None = None
+    kind: str | None = None
+    name: str | None = None
+    uid: str | None = None
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> OwnerReference:
+        """Create from a kubernetes OwnerReference object."""
+        if obj is None:
+            return cls()
+        return cls(
+            api_version=getattr(obj, "api_version", None),
+            kind=getattr(obj, "kind", None),
+            name=getattr(obj, "name", None),
+            uid=getattr(obj, "uid", None),
+        )
+
+
+def _safe_get(obj: Any, *attrs: str, default: Any = None) -> Any:
+    """Safely traverse nested attributes on kubernetes SDK objects."""
+    current = obj
+    for attr in attrs:
+        if current is None:
+            return default
+        current = getattr(current, attr, None)
+    return current if current is not None else default
+
+
+def _get_timestamp(obj: Any) -> str | None:
+    """Extract ISO timestamp string from a datetime or string."""
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    return str(obj)
+
+
+def _get_labels(obj: Any) -> dict[str, str] | None:
+    """Extract labels dict, returning None if empty."""
+    labels = _safe_get(obj, "metadata", "labels")
+    return dict(labels) if labels else None
+
+
+def _get_annotations(obj: Any) -> dict[str, str] | None:
+    """Extract annotations dict, returning None if empty."""
+    annotations = _safe_get(obj, "metadata", "annotations")
+    return dict(annotations) if annotations else None

--- a/src/system_operations_manager/integrations/kubernetes/models/cluster.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/cluster.py
@@ -1,0 +1,142 @@
+"""Kubernetes cluster-level resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class NamespaceSummary(K8sEntityBase):
+    """Namespace display model."""
+
+    _entity_name: ClassVar[str] = "namespace"
+
+    status: str = Field(default="Active", description="Namespace phase")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> NamespaceSummary:
+        """Create from a kubernetes V1Namespace object."""
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            status=_safe_get(obj, "status", "phase", default="Active"),
+        )
+
+
+class NodeSummary(K8sEntityBase):
+    """Node display model."""
+
+    _entity_name: ClassVar[str] = "node"
+
+    status: str = Field(default="Unknown", description="Node status")
+    roles: list[str] = Field(default_factory=list, description="Node roles")
+    version: str | None = Field(default=None, description="Kubelet version")
+    internal_ip: str | None = Field(default=None, description="Internal IP address")
+    os_image: str | None = Field(default=None, description="OS image")
+    kernel_version: str | None = Field(default=None, description="Kernel version")
+    container_runtime: str | None = Field(default=None, description="Container runtime")
+    cpu_capacity: str | None = Field(default=None, description="CPU capacity")
+    memory_capacity: str | None = Field(default=None, description="Memory capacity")
+    pods_capacity: str | None = Field(default=None, description="Pod capacity")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> NodeSummary:
+        """Create from a kubernetes V1Node object."""
+        # Extract roles from labels
+        labels = _safe_get(obj, "metadata", "labels") or {}
+        roles = []
+        for key in labels:
+            if key.startswith("node-role.kubernetes.io/"):
+                role = key.split("/", 1)[1]
+                if role:
+                    roles.append(role)
+        if not roles:
+            roles = ["<none>"]
+
+        # Determine node status from conditions
+        status = "Unknown"
+        conditions = _safe_get(obj, "status", "conditions") or []
+        for cond in conditions:
+            if getattr(cond, "type", None) == "Ready":
+                status = "Ready" if getattr(cond, "status", "") == "True" else "NotReady"
+                break
+
+        # Internal IP
+        addresses = _safe_get(obj, "status", "addresses") or []
+        internal_ip = None
+        for addr in addresses:
+            if getattr(addr, "type", None) == "InternalIP":
+                internal_ip = getattr(addr, "address", None)
+                break
+
+        # Node info
+        node_info = _safe_get(obj, "status", "node_info")
+        capacity = _safe_get(obj, "status", "capacity") or {}
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            status=status,
+            roles=roles,
+            version=_safe_get(node_info, "kubelet_version"),
+            internal_ip=internal_ip,
+            os_image=_safe_get(node_info, "os_image"),
+            kernel_version=_safe_get(node_info, "kernel_version"),
+            container_runtime=_safe_get(node_info, "container_runtime_version"),
+            cpu_capacity=capacity.get("cpu") if isinstance(capacity, dict) else None,
+            memory_capacity=capacity.get("memory") if isinstance(capacity, dict) else None,
+            pods_capacity=capacity.get("pods") if isinstance(capacity, dict) else None,
+        )
+
+
+class EventSummary(K8sEntityBase):
+    """Event display model."""
+
+    _entity_name: ClassVar[str] = "event"
+
+    type: str = Field(default="Normal", description="Event type (Normal/Warning)")
+    reason: str | None = Field(default=None, description="Event reason")
+    message: str | None = Field(default=None, description="Event message")
+    source_component: str | None = Field(default=None, description="Event source component")
+    first_timestamp: str | None = Field(default=None, description="First occurrence")
+    last_timestamp: str | None = Field(default=None, description="Last occurrence")
+    count: int = Field(default=1, description="Occurrence count")
+    involved_object_kind: str | None = Field(default=None, description="Involved object kind")
+    involved_object_name: str | None = Field(default=None, description="Involved object name")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> EventSummary:
+        """Create from a kubernetes CoreV1Event object."""
+        source = getattr(obj, "source", None)
+        involved = getattr(obj, "involved_object", None)
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            type=getattr(obj, "type", "Normal") or "Normal",
+            reason=getattr(obj, "reason", None),
+            message=getattr(obj, "message", None),
+            source_component=_safe_get(source, "component"),
+            first_timestamp=_get_timestamp(getattr(obj, "first_timestamp", None)),
+            last_timestamp=_get_timestamp(getattr(obj, "last_timestamp", None)),
+            count=getattr(obj, "count", 1) or 1,
+            involved_object_kind=_safe_get(involved, "kind"),
+            involved_object_name=_safe_get(involved, "name"),
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/configuration.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/configuration.py
@@ -1,0 +1,72 @@
+"""Kubernetes configuration resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class ConfigMapSummary(K8sEntityBase):
+    """ConfigMap display model."""
+
+    _entity_name: ClassVar[str] = "configmap"
+
+    data_keys: list[str] = Field(default_factory=list, description="Data key names")
+    binary_data_keys: list[str] = Field(default_factory=list, description="Binary data key names")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ConfigMapSummary:
+        """Create from a kubernetes V1ConfigMap object."""
+        data = getattr(obj, "data", None) or {}
+        binary_data = getattr(obj, "binary_data", None) or {}
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            data_keys=sorted(data.keys()),
+            binary_data_keys=sorted(binary_data.keys()),
+        )
+
+
+class SecretSummary(K8sEntityBase):
+    """Secret display model.
+
+    SECURITY: Never includes actual secret data values. Only key names are exposed.
+    """
+
+    _entity_name: ClassVar[str] = "secret"
+
+    type: str = Field(default="Opaque", description="Secret type")
+    data_keys: list[str] = Field(default_factory=list, description="Data key names (values hidden)")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> SecretSummary:
+        """Create from a kubernetes V1Secret object.
+
+        Only extracts key names - never includes secret values.
+        """
+        data = getattr(obj, "data", None) or {}
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            type=getattr(obj, "type", "Opaque") or "Opaque",
+            data_keys=sorted(data.keys()),
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/jobs.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/jobs.py
@@ -1,0 +1,77 @@
+"""Kubernetes job resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class JobSummary(K8sEntityBase):
+    """Job display model."""
+
+    _entity_name: ClassVar[str] = "job"
+
+    completions: int | None = Field(default=None, description="Desired completions")
+    succeeded: int = Field(default=0, description="Succeeded pod count")
+    failed: int = Field(default=0, description="Failed pod count")
+    active: int = Field(default=0, description="Active pod count")
+    start_time: str | None = Field(default=None, description="Job start time")
+    completion_time: str | None = Field(default=None, description="Job completion time")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> JobSummary:
+        """Create from a kubernetes V1Job object."""
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            completions=_safe_get(obj, "spec", "completions"),
+            succeeded=_safe_get(obj, "status", "succeeded", default=0) or 0,
+            failed=_safe_get(obj, "status", "failed", default=0) or 0,
+            active=_safe_get(obj, "status", "active", default=0) or 0,
+            start_time=_get_timestamp(_safe_get(obj, "status", "start_time")),
+            completion_time=_get_timestamp(_safe_get(obj, "status", "completion_time")),
+        )
+
+
+class CronJobSummary(K8sEntityBase):
+    """CronJob display model."""
+
+    _entity_name: ClassVar[str] = "cronjob"
+
+    schedule: str = Field(default="", description="Cron schedule expression")
+    suspend: bool = Field(default=False, description="Whether the CronJob is suspended")
+    active_count: int = Field(default=0, description="Number of active jobs")
+    last_schedule_time: str | None = Field(default=None, description="Last schedule time")
+    last_successful_time: str | None = Field(default=None, description="Last successful time")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> CronJobSummary:
+        """Create from a kubernetes V1CronJob object."""
+        active_jobs = _safe_get(obj, "status", "active") or []
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            schedule=_safe_get(obj, "spec", "schedule", default=""),
+            suspend=_safe_get(obj, "spec", "suspend", default=False) or False,
+            active_count=len(active_jobs),
+            last_schedule_time=_get_timestamp(_safe_get(obj, "status", "last_schedule_time")),
+            last_successful_time=_get_timestamp(_safe_get(obj, "status", "last_successful_time")),
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/networking.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/networking.py
@@ -1,0 +1,182 @@
+"""Kubernetes networking resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class ServicePort(K8sEntityBase):
+    """Service port definition."""
+
+    _entity_name: ClassVar[str] = "serviceport"
+
+    port: int = Field(description="Service port number")
+    target_port: str | int | None = Field(default=None, description="Target port")
+    protocol: str = Field(default="TCP", description="Protocol")
+    node_port: int | None = Field(default=None, description="Node port")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ServicePort:
+        """Create from a kubernetes V1ServicePort object."""
+        target_port = getattr(obj, "target_port", None)
+        if target_port is not None:
+            target_port = str(target_port)
+        return cls(
+            name=getattr(obj, "name", "") or "",
+            port=getattr(obj, "port", 0),
+            target_port=target_port,
+            protocol=getattr(obj, "protocol", "TCP") or "TCP",
+            node_port=getattr(obj, "node_port", None),
+        )
+
+
+class ServiceSummary(K8sEntityBase):
+    """Service display model."""
+
+    _entity_name: ClassVar[str] = "service"
+
+    type: str = Field(default="ClusterIP", description="Service type")
+    cluster_ip: str | None = Field(default=None, description="Cluster IP")
+    external_ip: str | None = Field(default=None, description="External IP")
+    ports: list[ServicePort] = Field(default_factory=list, description="Service ports")
+    selector: dict[str, str] | None = Field(default=None, description="Pod selector")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ServiceSummary:
+        """Create from a kubernetes V1Service object."""
+        spec = getattr(obj, "spec", None)
+        ports = _safe_get(obj, "spec", "ports") or []
+
+        # External IP from status or spec
+        external_ips = _safe_get(obj, "spec", "external_i_ps") or []
+        lb_ingress = _safe_get(obj, "status", "load_balancer", "ingress") or []
+        external_ip = None
+        if external_ips:
+            external_ip = external_ips[0]
+        elif lb_ingress:
+            external_ip = getattr(lb_ingress[0], "ip", None) or getattr(
+                lb_ingress[0], "hostname", None
+            )
+
+        selector = _safe_get(spec, "selector")
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            type=_safe_get(spec, "type", default="ClusterIP"),
+            cluster_ip=_safe_get(spec, "cluster_ip"),
+            external_ip=external_ip,
+            ports=[ServicePort.from_k8s_object(p) for p in ports],
+            selector=dict(selector) if selector else None,
+        )
+
+
+class IngressRule(K8sEntityBase):
+    """Ingress rule definition."""
+
+    _entity_name: ClassVar[str] = "ingressrule"
+
+    host: str | None = Field(default=None, description="Hostname")
+    paths: list[str] = Field(default_factory=list, description="Path patterns")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> IngressRule:
+        """Create from a kubernetes V1IngressRule object."""
+        host = getattr(obj, "host", None)
+        http = getattr(obj, "http", None)
+        paths: list[str] = []
+        if http and (http_paths := getattr(http, "paths", None)):
+            for p in http_paths:
+                path = getattr(p, "path", "/")
+                paths.append(str(path) if path else "/")
+
+        return cls(
+            name=host or "*",
+            host=host,
+            paths=paths,
+        )
+
+
+class IngressSummary(K8sEntityBase):
+    """Ingress display model."""
+
+    _entity_name: ClassVar[str] = "ingress"
+
+    class_name: str | None = Field(default=None, description="Ingress class")
+    hosts: list[str] = Field(default_factory=list, description="Hostnames")
+    addresses: list[str] = Field(default_factory=list, description="Load balancer addresses")
+    rules: list[IngressRule] = Field(default_factory=list, description="Ingress rules")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> IngressSummary:
+        """Create from a kubernetes V1Ingress object."""
+        rules_raw = _safe_get(obj, "spec", "rules") or []
+        rules = [IngressRule.from_k8s_object(r) for r in rules_raw]
+        hosts = [r.host for r in rules if r.host]
+
+        # Addresses from status
+        lb_ingress = _safe_get(obj, "status", "load_balancer", "ingress") or []
+        addresses = []
+        for ing in lb_ingress:
+            addr = getattr(ing, "ip", None) or getattr(ing, "hostname", None)
+            if addr:
+                addresses.append(str(addr))
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            class_name=_safe_get(obj, "spec", "ingress_class_name"),
+            hosts=hosts,
+            addresses=addresses,
+            rules=rules,
+        )
+
+
+class NetworkPolicySummary(K8sEntityBase):
+    """NetworkPolicy display model."""
+
+    _entity_name: ClassVar[str] = "networkpolicy"
+
+    pod_selector: dict[str, str] | None = Field(default=None, description="Pod selector")
+    policy_types: list[str] = Field(default_factory=list, description="Policy types")
+    ingress_rules_count: int = Field(default=0, description="Number of ingress rules")
+    egress_rules_count: int = Field(default=0, description="Number of egress rules")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> NetworkPolicySummary:
+        """Create from a kubernetes V1NetworkPolicy object."""
+        pod_selector_labels = _safe_get(obj, "spec", "pod_selector", "match_labels")
+        policy_types = _safe_get(obj, "spec", "policy_types") or []
+        ingress_rules = _safe_get(obj, "spec", "ingress") or []
+        egress_rules = _safe_get(obj, "spec", "egress") or []
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            pod_selector=dict(pod_selector_labels) if pod_selector_labels else None,
+            policy_types=list(policy_types),
+            ingress_rules_count=len(ingress_rules),
+            egress_rules_count=len(egress_rules),
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/rbac.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/rbac.py
@@ -1,0 +1,139 @@
+"""Kubernetes RBAC resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class Subject(BaseModel):
+    """RBAC subject (user, group, or service account)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kind: str = Field(description="Subject kind (User, Group, ServiceAccount)")
+    name: str = Field(description="Subject name")
+    namespace: str | None = Field(default=None, description="Subject namespace")
+    api_group: str | None = Field(default=None, description="API group")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> Subject:
+        """Create from a kubernetes V1Subject object."""
+        return cls(
+            kind=getattr(obj, "kind", "") or "",
+            name=getattr(obj, "name", "") or "",
+            namespace=getattr(obj, "namespace", None),
+            api_group=getattr(obj, "api_group", None),
+        )
+
+
+class PolicyRule(BaseModel):
+    """RBAC policy rule."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    verbs: list[str] = Field(default_factory=list, description="Allowed verbs")
+    api_groups: list[str] = Field(default_factory=list, description="API groups")
+    resources: list[str] = Field(default_factory=list, description="Resources")
+    resource_names: list[str] = Field(default_factory=list, description="Resource names")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> PolicyRule:
+        """Create from a kubernetes V1PolicyRule object."""
+        return cls(
+            verbs=list(getattr(obj, "verbs", []) or []),
+            api_groups=list(getattr(obj, "api_groups", []) or []),
+            resources=list(getattr(obj, "resources", []) or []),
+            resource_names=list(getattr(obj, "resource_names", []) or []),
+        )
+
+
+class ServiceAccountSummary(K8sEntityBase):
+    """ServiceAccount display model."""
+
+    _entity_name: ClassVar[str] = "serviceaccount"
+
+    secrets_count: int = Field(default=0, description="Number of associated secrets")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ServiceAccountSummary:
+        """Create from a kubernetes V1ServiceAccount object."""
+        secrets = getattr(obj, "secrets", None) or []
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            secrets_count=len(secrets),
+        )
+
+
+class RoleSummary(K8sEntityBase):
+    """Role/ClusterRole display model."""
+
+    _entity_name: ClassVar[str] = "role"
+
+    is_cluster_role: bool = Field(default=False, description="Whether this is a ClusterRole")
+    rules_count: int = Field(default=0, description="Number of policy rules")
+    rules: list[PolicyRule] = Field(default_factory=list, description="Policy rules")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any, *, is_cluster_role: bool = False) -> RoleSummary:
+        """Create from a kubernetes V1Role or V1ClusterRole object."""
+        rules_raw = getattr(obj, "rules", None) or []
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            is_cluster_role=is_cluster_role,
+            rules_count=len(rules_raw),
+            rules=[PolicyRule.from_k8s_object(r) for r in rules_raw],
+        )
+
+
+class RoleBindingSummary(K8sEntityBase):
+    """RoleBinding/ClusterRoleBinding display model."""
+
+    _entity_name: ClassVar[str] = "rolebinding"
+
+    is_cluster_binding: bool = Field(
+        default=False, description="Whether this is a ClusterRoleBinding"
+    )
+    role_ref_kind: str | None = Field(default=None, description="Role reference kind")
+    role_ref_name: str | None = Field(default=None, description="Role reference name")
+    subjects: list[Subject] = Field(default_factory=list, description="Binding subjects")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any, *, is_cluster_binding: bool = False) -> RoleBindingSummary:
+        """Create from a kubernetes V1RoleBinding or V1ClusterRoleBinding object."""
+        role_ref = getattr(obj, "role_ref", None)
+        subjects_raw = getattr(obj, "subjects", None) or []
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            is_cluster_binding=is_cluster_binding,
+            role_ref_kind=_safe_get(role_ref, "kind"),
+            role_ref_name=_safe_get(role_ref, "name"),
+            subjects=[Subject.from_k8s_object(s) for s in subjects_raw],
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/storage.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/storage.py
@@ -1,0 +1,117 @@
+"""Kubernetes storage resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class PersistentVolumeSummary(K8sEntityBase):
+    """PersistentVolume display model."""
+
+    _entity_name: ClassVar[str] = "persistentvolume"
+
+    capacity: str | None = Field(default=None, description="Storage capacity")
+    access_modes: list[str] = Field(default_factory=list, description="Access modes")
+    reclaim_policy: str | None = Field(default=None, description="Reclaim policy")
+    status: str = Field(default="Available", description="Volume phase")
+    storage_class: str | None = Field(default=None, description="Storage class name")
+    claim_ref: str | None = Field(default=None, description="Bound PVC reference")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> PersistentVolumeSummary:
+        """Create from a kubernetes V1PersistentVolume object."""
+        capacity = _safe_get(obj, "spec", "capacity") or {}
+        storage_capacity = capacity.get("storage") if isinstance(capacity, dict) else None
+
+        # Claim reference
+        claim = _safe_get(obj, "spec", "claim_ref")
+        claim_ref = None
+        if claim:
+            claim_ns = getattr(claim, "namespace", "")
+            claim_name = getattr(claim, "name", "")
+            claim_ref = f"{claim_ns}/{claim_name}" if claim_ns else claim_name
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            capacity=str(storage_capacity) if storage_capacity else None,
+            access_modes=list(_safe_get(obj, "spec", "access_modes") or []),
+            reclaim_policy=_safe_get(obj, "spec", "persistent_volume_reclaim_policy"),
+            status=_safe_get(obj, "status", "phase", default="Available"),
+            storage_class=_safe_get(obj, "spec", "storage_class_name"),
+            claim_ref=claim_ref,
+        )
+
+
+class PersistentVolumeClaimSummary(K8sEntityBase):
+    """PersistentVolumeClaim display model."""
+
+    _entity_name: ClassVar[str] = "persistentvolumeclaim"
+
+    status: str = Field(default="Pending", description="PVC phase")
+    volume: str | None = Field(default=None, description="Bound volume name")
+    capacity: str | None = Field(default=None, description="Allocated capacity")
+    access_modes: list[str] = Field(default_factory=list, description="Access modes")
+    storage_class: str | None = Field(default=None, description="Storage class name")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> PersistentVolumeClaimSummary:
+        """Create from a kubernetes V1PersistentVolumeClaim object."""
+        # Capacity from status (actual allocation)
+        status_capacity = _safe_get(obj, "status", "capacity") or {}
+        capacity = status_capacity.get("storage") if isinstance(status_capacity, dict) else None
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            status=_safe_get(obj, "status", "phase", default="Pending"),
+            volume=_safe_get(obj, "spec", "volume_name"),
+            capacity=str(capacity) if capacity else None,
+            access_modes=list(_safe_get(obj, "status", "access_modes") or []),
+            storage_class=_safe_get(obj, "spec", "storage_class_name"),
+        )
+
+
+class StorageClassSummary(K8sEntityBase):
+    """StorageClass display model."""
+
+    _entity_name: ClassVar[str] = "storageclass"
+
+    provisioner: str = Field(default="", description="Volume provisioner")
+    reclaim_policy: str | None = Field(default=None, description="Reclaim policy")
+    volume_binding_mode: str | None = Field(default=None, description="Volume binding mode")
+    allow_volume_expansion: bool = Field(
+        default=False, description="Whether volume expansion is allowed"
+    )
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> StorageClassSummary:
+        """Create from a kubernetes V1StorageClass object."""
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            provisioner=getattr(obj, "provisioner", "") or "",
+            reclaim_policy=getattr(obj, "reclaim_policy", None),
+            volume_binding_mode=getattr(obj, "volume_binding_mode", None),
+            allow_volume_expansion=getattr(obj, "allow_volume_expansion", False) or False,
+        )

--- a/src/system_operations_manager/integrations/kubernetes/models/workloads.py
+++ b/src/system_operations_manager/integrations/kubernetes/models/workloads.py
@@ -1,0 +1,205 @@
+"""Kubernetes workload resource display models."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from system_operations_manager.integrations.kubernetes.models.base import (
+    K8sEntityBase,
+    OwnerReference,
+    _get_annotations,
+    _get_labels,
+    _get_timestamp,
+    _safe_get,
+)
+
+
+class ContainerStatus(K8sEntityBase):
+    """Container status within a pod."""
+
+    _entity_name: ClassVar[str] = "container"
+
+    image: str | None = Field(default=None, description="Container image")
+    ready: bool = Field(default=False, description="Whether container is ready")
+    restart_count: int = Field(default=0, description="Number of restarts")
+    state: str = Field(default="unknown", description="Current state")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ContainerStatus:
+        """Create from a kubernetes ContainerStatus object."""
+        state = "unknown"
+        if obj_state := getattr(obj, "state", None):
+            if getattr(obj_state, "running", None):
+                state = "running"
+            elif getattr(obj_state, "waiting", None):
+                reason = _safe_get(obj_state, "waiting", "reason", default="Waiting")
+                state = str(reason)
+            elif getattr(obj_state, "terminated", None):
+                reason = _safe_get(obj_state, "terminated", "reason", default="Terminated")
+                state = str(reason)
+
+        return cls(
+            name=getattr(obj, "name", ""),
+            image=getattr(obj, "image", None),
+            ready=getattr(obj, "ready", False) or False,
+            restart_count=getattr(obj, "restart_count", 0) or 0,
+            state=state,
+        )
+
+
+class PodSummary(K8sEntityBase):
+    """Pod display model."""
+
+    _entity_name: ClassVar[str] = "pod"
+
+    phase: str = Field(default="Unknown", description="Pod phase")
+    node_name: str | None = Field(default=None, description="Node the pod is running on")
+    pod_ip: str | None = Field(default=None, description="Pod IP address")
+    restarts: int = Field(default=0, description="Total container restarts")
+    ready_count: int = Field(default=0, description="Number of ready containers")
+    total_count: int = Field(default=0, description="Total number of containers")
+    containers: list[ContainerStatus] = Field(
+        default_factory=list, description="Container statuses"
+    )
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> PodSummary:
+        """Create from a kubernetes V1Pod object."""
+        container_statuses = _safe_get(obj, "status", "container_statuses") or []
+        containers = [ContainerStatus.from_k8s_object(cs) for cs in container_statuses]
+        restarts = sum(c.restart_count for c in containers)
+        ready_count = sum(1 for c in containers if c.ready)
+
+        # Total containers from spec
+        spec_containers = _safe_get(obj, "spec", "containers") or []
+        total_count = len(spec_containers)
+
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            phase=_safe_get(obj, "status", "phase", default="Unknown"),
+            node_name=_safe_get(obj, "spec", "node_name"),
+            pod_ip=_safe_get(obj, "status", "pod_ip"),
+            restarts=restarts,
+            ready_count=ready_count,
+            total_count=total_count,
+            containers=containers,
+        )
+
+
+class DeploymentSummary(K8sEntityBase):
+    """Deployment display model."""
+
+    _entity_name: ClassVar[str] = "deployment"
+
+    replicas: int = Field(default=0, description="Desired replicas")
+    ready_replicas: int = Field(default=0, description="Ready replicas")
+    available_replicas: int = Field(default=0, description="Available replicas")
+    updated_replicas: int = Field(default=0, description="Updated replicas")
+    strategy: str | None = Field(default=None, description="Deployment strategy")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> DeploymentSummary:
+        """Create from a kubernetes V1Deployment object."""
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            replicas=_safe_get(obj, "spec", "replicas", default=0) or 0,
+            ready_replicas=_safe_get(obj, "status", "ready_replicas", default=0) or 0,
+            available_replicas=_safe_get(obj, "status", "available_replicas", default=0) or 0,
+            updated_replicas=_safe_get(obj, "status", "updated_replicas", default=0) or 0,
+            strategy=_safe_get(obj, "spec", "strategy", "type"),
+        )
+
+
+class StatefulSetSummary(K8sEntityBase):
+    """StatefulSet display model."""
+
+    _entity_name: ClassVar[str] = "statefulset"
+
+    replicas: int = Field(default=0, description="Desired replicas")
+    ready_replicas: int = Field(default=0, description="Ready replicas")
+    service_name: str | None = Field(default=None, description="Governing service name")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> StatefulSetSummary:
+        """Create from a kubernetes V1StatefulSet object."""
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            replicas=_safe_get(obj, "spec", "replicas", default=0) or 0,
+            ready_replicas=_safe_get(obj, "status", "ready_replicas", default=0) or 0,
+            service_name=_safe_get(obj, "spec", "service_name"),
+        )
+
+
+class DaemonSetSummary(K8sEntityBase):
+    """DaemonSet display model."""
+
+    _entity_name: ClassVar[str] = "daemonset"
+
+    desired_number_scheduled: int = Field(default=0, description="Desired pods")
+    current_number_scheduled: int = Field(default=0, description="Current pods")
+    number_ready: int = Field(default=0, description="Ready pods")
+    node_selector: dict[str, str] | None = Field(default=None, description="Node selector")
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> DaemonSetSummary:
+        """Create from a kubernetes V1DaemonSet object."""
+        node_selector = _safe_get(obj, "spec", "template", "spec", "node_selector")
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            desired_number_scheduled=_safe_get(obj, "status", "desired_number_scheduled", default=0)
+            or 0,
+            current_number_scheduled=_safe_get(obj, "status", "current_number_scheduled", default=0)
+            or 0,
+            number_ready=_safe_get(obj, "status", "number_ready", default=0) or 0,
+            node_selector=dict(node_selector) if node_selector else None,
+        )
+
+
+class ReplicaSetSummary(K8sEntityBase):
+    """ReplicaSet display model."""
+
+    _entity_name: ClassVar[str] = "replicaset"
+
+    replicas: int = Field(default=0, description="Desired replicas")
+    ready_replicas: int = Field(default=0, description="Ready replicas")
+    owner_references: list[OwnerReference] = Field(
+        default_factory=list, description="Owner references"
+    )
+
+    @classmethod
+    def from_k8s_object(cls, obj: Any) -> ReplicaSetSummary:
+        """Create from a kubernetes V1ReplicaSet object."""
+        owner_refs = _safe_get(obj, "metadata", "owner_references") or []
+        return cls(
+            name=_safe_get(obj, "metadata", "name", default=""),
+            namespace=_safe_get(obj, "metadata", "namespace"),
+            uid=_safe_get(obj, "metadata", "uid"),
+            creation_timestamp=_get_timestamp(_safe_get(obj, "metadata", "creation_timestamp")),
+            labels=_get_labels(obj),
+            annotations=_get_annotations(obj),
+            replicas=_safe_get(obj, "spec", "replicas", default=0) or 0,
+            ready_replicas=_safe_get(obj, "status", "ready_replicas", default=0) or 0,
+            owner_references=[OwnerReference.from_k8s_object(ref) for ref in owner_refs],
+        )

--- a/src/system_operations_manager/plugins/kubernetes/__init__.py
+++ b/src/system_operations_manager/plugins/kubernetes/__init__.py
@@ -1,0 +1,5 @@
+"""Kubernetes plugin - cluster management and resource operations."""
+
+from system_operations_manager.plugins.kubernetes.plugin import KubernetesPlugin
+
+__all__ = ["KubernetesPlugin"]

--- a/src/system_operations_manager/plugins/kubernetes/commands/__init__.py
+++ b/src/system_operations_manager/plugins/kubernetes/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Kubernetes CLI command modules."""

--- a/src/system_operations_manager/plugins/kubernetes/commands/base.py
+++ b/src/system_operations_manager/plugins/kubernetes/commands/base.py
@@ -1,0 +1,171 @@
+"""Base utilities for Kubernetes CLI commands.
+
+Provides common Typer options, error handling utilities,
+and shared functionality for all Kubernetes CLI commands.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from system_operations_manager.integrations.kubernetes.exceptions import (
+    KubernetesAuthError,
+    KubernetesConflictError,
+    KubernetesConnectionError,
+    KubernetesError,
+    KubernetesNotFoundError,
+    KubernetesTimeoutError,
+    KubernetesValidationError,
+)
+from system_operations_manager.plugins.kubernetes.formatters import OutputFormat
+
+# Shared console instance
+console = Console()
+
+
+# =============================================================================
+# Common Typer Option Annotations
+# =============================================================================
+
+OutputOption = Annotated[
+    OutputFormat,
+    typer.Option(
+        "--output",
+        "-o",
+        help="Output format: table, json, or yaml",
+        case_sensitive=False,
+    ),
+]
+
+NamespaceOption = Annotated[
+    str | None,
+    typer.Option(
+        "--namespace",
+        "-n",
+        help="Kubernetes namespace (defaults to config or 'default')",
+    ),
+]
+
+AllNamespacesOption = Annotated[
+    bool,
+    typer.Option(
+        "--all-namespaces",
+        "-A",
+        help="List resources across all namespaces",
+    ),
+]
+
+LabelSelectorOption = Annotated[
+    str | None,
+    typer.Option(
+        "--selector",
+        "-l",
+        help="Label selector (e.g., 'app=nginx,tier=frontend')",
+    ),
+]
+
+FieldSelectorOption = Annotated[
+    str | None,
+    typer.Option(
+        "--field-selector",
+        help="Field selector (e.g., 'status.phase=Running')",
+    ),
+]
+
+ForceOption = Annotated[
+    bool,
+    typer.Option(
+        "--force",
+        "-f",
+        help="Skip confirmation prompts",
+    ),
+]
+
+DryRunOption = Annotated[
+    bool,
+    typer.Option(
+        "--dry-run",
+        help="Only print what would be done, don't execute",
+    ),
+]
+
+
+# =============================================================================
+# Error Handling
+# =============================================================================
+
+
+def handle_k8s_error(error: KubernetesError) -> None:
+    """Handle Kubernetes errors with user-friendly output.
+
+    Args:
+        error: The Kubernetes error to handle.
+
+    Raises:
+        typer.Exit: Always exits with code 1.
+    """
+    if isinstance(error, KubernetesConnectionError):
+        console.print("[red]Error:[/red] Cannot connect to Kubernetes cluster")
+        console.print(f"  {error.message}")
+        if error.original_error:
+            console.print(f"  Cause: {error.original_error}")
+        console.print(
+            "\n[dim]Hint: Check that your kubeconfig is valid and the cluster is reachable.[/dim]"
+        )
+
+    elif isinstance(error, KubernetesAuthError):
+        console.print("[red]Error:[/red] Authentication/authorization failed")
+        console.print(f"  {error.message}")
+        console.print("\n[dim]Hint: Check your credentials, token, or RBAC permissions.[/dim]")
+
+    elif isinstance(error, KubernetesNotFoundError):
+        console.print("[red]Error:[/red] Resource not found")
+        console.print(f"  {error.message}")
+
+    elif isinstance(error, KubernetesValidationError):
+        console.print("[red]Error:[/red] Validation failed")
+        console.print(f"  {error.message}")
+        if error.validation_errors:
+            console.print("\n  Field errors:")
+            for field, err in error.validation_errors.items():
+                console.print(f"    - {field}: {err}")
+
+    elif isinstance(error, KubernetesConflictError):
+        console.print("[red]Error:[/red] Resource conflict")
+        console.print(f"  {error.message}")
+
+    elif isinstance(error, KubernetesTimeoutError):
+        console.print("[red]Error:[/red] Operation timed out")
+        console.print(f"  {error.message}")
+        console.print(
+            "\n[dim]Hint: Try increasing the timeout with --timeout or OPS_K8S_TIMEOUT.[/dim]"
+        )
+
+    else:
+        console.print(f"[red]Error:[/red] {error.message}")
+        if error.status_code:
+            console.print(f"  HTTP Status: {error.status_code}")
+
+    raise typer.Exit(1)
+
+
+# =============================================================================
+# Confirmation Utilities
+# =============================================================================
+
+
+def confirm_delete(resource_type: str, name: str, namespace: str | None = None) -> bool:
+    """Prompt user to confirm deletion."""
+    msg = f"Are you sure you want to delete {resource_type} '{name}'"
+    if namespace:
+        msg += f" in namespace '{namespace}'"
+    msg += "?"
+    return typer.confirm(msg, default=False)
+
+
+def confirm_action(message: str, default: bool = False) -> bool:
+    """Prompt user to confirm an action."""
+    return typer.confirm(message, default=default)

--- a/src/system_operations_manager/plugins/kubernetes/formatters.py
+++ b/src/system_operations_manager/plugins/kubernetes/formatters.py
@@ -1,0 +1,222 @@
+"""Output formatters for Kubernetes CLI commands.
+
+Implements the Strategy pattern for output formatting,
+allowing commands to output data in table, JSON, or YAML formats.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any
+
+import yaml
+from rich.console import Console
+
+from system_operations_manager.cli.output import Table
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats for CLI commands."""
+
+    TABLE = "table"
+    JSON = "json"
+    YAML = "yaml"
+
+
+class K8sFormatter(ABC):
+    """Abstract base class for Kubernetes output formatters."""
+
+    def __init__(self, console: Console) -> None:
+        self.console = console
+
+    @abstractmethod
+    def format_resource(self, resource: Any, title: str = "") -> None:
+        """Format and display a single resource."""
+
+    @abstractmethod
+    def format_list(
+        self,
+        resources: Sequence[Any],
+        columns: list[tuple[str, str]],
+        title: str = "",
+    ) -> None:
+        """Format and display a list of resources."""
+
+    @abstractmethod
+    def format_dict(self, data: dict[str, Any], title: str = "") -> None:
+        """Format and display a dictionary."""
+
+    def format_success(self, message: str) -> None:
+        """Display a success message."""
+        self.console.print(f"[green]{message}[/green]")
+
+    def format_error(self, message: str) -> None:
+        """Display an error message."""
+        self.console.print(f"[red]Error:[/red] {message}")
+
+
+class TableFormatter(K8sFormatter):
+    """Rich table output formatter."""
+
+    def format_resource(self, resource: Any, title: str = "") -> None:
+        """Format resource as a two-column key-value table."""
+        table = Table(title=title or "Resource Details", show_header=True)
+        table.add_column("Field", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
+
+        data = (
+            resource.model_dump(exclude_none=True) if hasattr(resource, "model_dump") else resource
+        )
+        for field, value in data.items():
+            table.add_row(field, self._format_value(value))
+
+        self.console.print(table)
+
+    def format_list(
+        self,
+        resources: Sequence[Any],
+        columns: list[tuple[str, str]],
+        title: str = "",
+    ) -> None:
+        """Format resources as a multi-column table."""
+        table = Table(title=title, show_header=True)
+
+        for _field_name, header in columns:
+            style = "cyan" if header.lower() in ("name", "namespace") else None
+            table.add_column(header, style=style)
+
+        for resource in resources:
+            data = resource.model_dump() if hasattr(resource, "model_dump") else resource
+            row = []
+            for field_name, _ in columns:
+                value = self._get_nested_value(data, field_name)
+                row.append(self._format_cell_value(value))
+            table.add_row(*row)
+
+        self.console.print(table)
+        self.console.print(f"\n[dim]Total: {len(resources)} resources[/dim]")
+
+    def format_dict(self, data: dict[str, Any], title: str = "") -> None:
+        """Format dictionary as a two-column table."""
+        table = Table(title=title, show_header=True)
+        table.add_column("Key", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
+
+        for key, value in data.items():
+            table.add_row(key, self._format_value(value))
+
+        self.console.print(table)
+
+    def _format_value(self, value: Any) -> str:
+        if isinstance(value, dict):
+            return json.dumps(value, indent=2)
+        elif isinstance(value, list):
+            if len(value) == 0:
+                return "[]"
+            elif all(isinstance(v, str) for v in value):
+                return ", ".join(value)
+            else:
+                return json.dumps(value, indent=2)
+        elif isinstance(value, bool):
+            return "[green]true[/green]" if value else "[red]false[/red]"
+        elif value is None:
+            return "[dim]-[/dim]"
+        else:
+            return str(value)
+
+    def _format_cell_value(self, value: Any) -> str:
+        if isinstance(value, dict):
+            if "name" in value:
+                return str(value["name"])
+            return json.dumps(value)
+        elif isinstance(value, list):
+            if len(value) == 0:
+                return "-"
+            items = [str(v) for v in value[:3]]
+            result = ", ".join(items)
+            if len(value) > 3:
+                result += f" (+{len(value) - 3})"
+            return result
+        elif isinstance(value, bool):
+            return "Yes" if value else "No"
+        elif value is None:
+            return "-"
+        else:
+            return str(value)
+
+    def _get_nested_value(self, data: dict[str, Any], field_path: str) -> Any:
+        keys = field_path.split(".")
+        value = data
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            else:
+                return None
+        return value
+
+
+class JsonFormatter(K8sFormatter):
+    """JSON output formatter."""
+
+    def format_resource(self, resource: Any, title: str = "") -> None:
+        data = (
+            resource.model_dump(exclude_none=True) if hasattr(resource, "model_dump") else resource
+        )
+        self.console.print(json.dumps(data, indent=2, default=str))
+
+    def format_list(
+        self,
+        resources: Sequence[Any],
+        columns: list[tuple[str, str]],
+        title: str = "",
+    ) -> None:
+        data = [
+            r.model_dump(exclude_none=True) if hasattr(r, "model_dump") else r for r in resources
+        ]
+        output = {"data": data, "total": len(data)}
+        self.console.print(json.dumps(output, indent=2, default=str))
+
+    def format_dict(self, data: dict[str, Any], title: str = "") -> None:
+        self.console.print(json.dumps(data, indent=2, default=str))
+
+
+class YamlFormatter(K8sFormatter):
+    """YAML output formatter."""
+
+    def format_resource(self, resource: Any, title: str = "") -> None:
+        data = (
+            resource.model_dump(exclude_none=True) if hasattr(resource, "model_dump") else resource
+        )
+        self.console.print(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+    def format_list(
+        self,
+        resources: Sequence[Any],
+        columns: list[tuple[str, str]],
+        title: str = "",
+    ) -> None:
+        data = [
+            r.model_dump(exclude_none=True) if hasattr(r, "model_dump") else r for r in resources
+        ]
+        self.console.print(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+    def format_dict(self, data: dict[str, Any], title: str = "") -> None:
+        self.console.print(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+
+def get_formatter(format_type: OutputFormat, console: Console | None = None) -> K8sFormatter:
+    """Factory function to get the appropriate formatter."""
+    if console is None:
+        console = Console()
+
+    formatters: dict[OutputFormat, type[K8sFormatter]] = {
+        OutputFormat.TABLE: TableFormatter,
+        OutputFormat.JSON: JsonFormatter,
+        OutputFormat.YAML: YamlFormatter,
+    }
+
+    formatter_class = formatters.get(format_type, TableFormatter)
+    return formatter_class(console)


### PR DESCRIPTION
## Summary

- **Integration layer**: Multi-cluster `KubernetesClient` wrapping the official kubernetes Python client with lazy API group accessors (CoreV1, AppsV1, BatchV1, NetworkingV1, RBAC, Storage, Version), context switching, tenacity retry, and error translation to custom exception hierarchy
- **Resource models**: 27 Pydantic display models for all 23 K8s entity types (pods, deployments, statefulsets, daemonsets, replicasets, jobs, cronjobs, services, ingresses, networkpolicies, configmaps, secrets, namespaces, nodes, events, PVs, PVCs, storageclasses, serviceaccounts, roles, clusterroles, rolebindings, clusterrolebindings) with `from_k8s_object()` classmethods
- **Plugin skeleton**: `KubernetesPlugin` class with `ops k8s status`, `ops k8s contexts`, `ops k8s use-context` commands, output formatters (table/json/yaml), shared CLI options (namespace, label selector, all-namespaces, dry-run, force), and pyproject.toml entry point

This is the first PR in the Kubernetes plugin epic (Tasks 1-3 of 37). Follows the same 3-layer architecture as the Kong plugin.

## Test plan

- [ ] `ruff check` and `ruff format` pass on all new files
- [ ] All model and plugin imports resolve correctly in the poetry venv
- [ ] `ops k8s --help` shows command groups after plugin registration
- [ ] `ops k8s status` shows cluster connectivity (requires kubeconfig)
- [ ] Secret model never exposes actual secret values (only key names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)