### PR TITLE
feat(plugins): add Kubernetes service managers

### DIFF
--- a/src/system_operations_manager/services/kubernetes/__init__.py
+++ b/src/system_operations_manager/services/kubernetes/__init__.py
@@ -1,8 +1,27 @@
 """Kubernetes service module.
 
 Provides centralized Kubernetes integration for the system operations manager.
+Includes resource managers for all major Kubernetes resource types.
 """
 
 from system_operations_manager.services.kubernetes.client import KubernetesService
+from system_operations_manager.services.kubernetes.configuration_manager import (
+    ConfigurationManager,
+)
+from system_operations_manager.services.kubernetes.job_manager import JobManager
+from system_operations_manager.services.kubernetes.namespace_manager import NamespaceClusterManager
+from system_operations_manager.services.kubernetes.networking_manager import NetworkingManager
+from system_operations_manager.services.kubernetes.rbac_manager import RBACManager
+from system_operations_manager.services.kubernetes.storage_manager import StorageManager
+from system_operations_manager.services.kubernetes.workload_manager import WorkloadManager
 
-__all__ = ["KubernetesService"]
+__all__ = [
+    "ConfigurationManager",
+    "JobManager",
+    "KubernetesService",
+    "NamespaceClusterManager",
+    "NetworkingManager",
+    "RBACManager",
+    "StorageManager",
+    "WorkloadManager",
+]

--- a/src/system_operations_manager/services/kubernetes/base.py
+++ b/src/system_operations_manager/services/kubernetes/base.py
@@ -1,0 +1,80 @@
+"""Base manager for Kubernetes service managers.
+
+Provides shared infrastructure for all Kubernetes resource managers,
+including client access, namespace resolution, and error translation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+import structlog
+
+if TYPE_CHECKING:
+    from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+
+logger = structlog.get_logger()
+
+
+class K8sBaseManager:
+    """Base class for Kubernetes service managers.
+
+    Provides shared concerns for all managers:
+    - Client reference and API group access
+    - Structured logging with entity binding
+    - Namespace resolution with config fallback
+    - Consistent API error translation
+
+    Subclasses set ``_entity_name`` for structured log context.
+
+    Example:
+        >>> class WorkloadManager(K8sBaseManager):
+        ...     _entity_name = "workload"
+    """
+
+    _entity_name: str = ""
+
+    def __init__(self, client: KubernetesClient) -> None:
+        """Initialize the manager.
+
+        Args:
+            client: Kubernetes API client instance.
+        """
+        self._client = client
+        self._log = logger.bind(entity=self._entity_name)
+
+    def _resolve_namespace(self, namespace: str | None) -> str:
+        """Resolve namespace, falling back to the client default.
+
+        Args:
+            namespace: Explicit namespace or None for default.
+
+        Returns:
+            The resolved namespace string.
+        """
+        return namespace or self._client.default_namespace
+
+    def _handle_api_error(
+        self,
+        e: Exception,
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        namespace: str | None = None,
+    ) -> NoReturn:
+        """Translate a Kubernetes API exception and re-raise.
+
+        Args:
+            e: The original exception (typically ApiException).
+            resource_type: Type of resource being operated on.
+            resource_name: Name of the resource.
+            namespace: Namespace of the resource.
+
+        Raises:
+            KubernetesError: Always raises an appropriate subclass.
+        """
+        raise self._client.translate_api_exception(
+            e,
+            resource_type=resource_type,
+            resource_name=resource_name,
+            namespace=namespace,
+        )

--- a/src/system_operations_manager/services/kubernetes/configuration_manager.py
+++ b/src/system_operations_manager/services/kubernetes/configuration_manager.py
@@ -1,0 +1,401 @@
+"""Kubernetes configuration resource manager.
+
+Manages ConfigMaps and Secrets through the Kubernetes API.
+Secret values are never exposed in display models for security.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.configuration import (
+    ConfigMapSummary,
+    SecretSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class ConfigurationManager(K8sBaseManager):
+    """Manager for Kubernetes configuration resources.
+
+    Provides CRUD operations for ConfigMaps and Secrets, including
+    specialized Secret types (TLS, docker-registry).
+
+    Security: Secret values are never included in display model responses.
+    """
+
+    _entity_name = "configuration"
+
+    # =========================================================================
+    # ConfigMap Operations
+    # =========================================================================
+
+    def list_config_maps(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[ConfigMapSummary]:
+        """List configmaps.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of configmap summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_configmaps", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_config_map_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_config_map(namespace=ns, **kwargs)
+
+            items = [ConfigMapSummary.from_k8s_object(cm) for cm in result.items]
+            self._log.debug("listed_configmaps", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", None, ns)
+
+    def get_config_map(self, name: str, namespace: str | None = None) -> ConfigMapSummary:
+        """Get a single configmap by name (metadata only).
+
+        Args:
+            name: ConfigMap name.
+            namespace: Target namespace.
+
+        Returns:
+            ConfigMap summary (keys listed, values not included).
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_configmap", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_config_map(name=name, namespace=ns)
+            return ConfigMapSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", name, ns)
+
+    def get_config_map_data(self, name: str, namespace: str | None = None) -> dict[str, str]:
+        """Get the actual data values of a configmap.
+
+        Args:
+            name: ConfigMap name.
+            namespace: Target namespace.
+
+        Returns:
+            Dictionary of key-value pairs.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_configmap_data", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_config_map(name=name, namespace=ns)
+            return dict(result.data or {})
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", name, ns)
+
+    def create_config_map(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        data: dict[str, str] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ConfigMapSummary:
+        """Create a configmap.
+
+        Args:
+            name: ConfigMap name.
+            namespace: Target namespace.
+            data: Key-value pairs for the configmap.
+            labels: ConfigMap labels.
+
+        Returns:
+            Created configmap summary.
+        """
+        from kubernetes.client import V1ConfigMap, V1ObjectMeta
+
+        ns = self._resolve_namespace(namespace)
+
+        body = V1ConfigMap(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            data=data,
+        )
+
+        self._log.info("creating_configmap", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.create_namespaced_config_map(namespace=ns, body=body)
+            self._log.info("created_configmap", name=name, namespace=ns)
+            return ConfigMapSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", name, ns)
+
+    def update_config_map(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        data: dict[str, str] | None = None,
+    ) -> ConfigMapSummary:
+        """Update a configmap's data (patch).
+
+        Args:
+            name: ConfigMap name.
+            namespace: Target namespace.
+            data: New key-value pairs (replaces existing data).
+
+        Returns:
+            Updated configmap summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_configmap", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {}
+            if data is not None:
+                patch["data"] = data
+
+            result = self._client.core_v1.patch_namespaced_config_map(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_configmap", name=name, namespace=ns)
+            return ConfigMapSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", name, ns)
+
+    def delete_config_map(self, name: str, namespace: str | None = None) -> None:
+        """Delete a configmap.
+
+        Args:
+            name: ConfigMap name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_configmap", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_config_map(name=name, namespace=ns)
+            self._log.info("deleted_configmap", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "ConfigMap", name, ns)
+
+    # =========================================================================
+    # Secret Operations
+    # =========================================================================
+
+    def list_secrets(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[SecretSummary]:
+        """List secrets (keys only, values hidden).
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of secret summaries (no secret values).
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_secrets", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_secret_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_secret(namespace=ns, **kwargs)
+
+            items = [SecretSummary.from_k8s_object(s) for s in result.items]
+            self._log.debug("listed_secrets", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Secret", None, ns)
+
+    def get_secret(self, name: str, namespace: str | None = None) -> SecretSummary:
+        """Get a single secret by name (keys only, values hidden).
+
+        Args:
+            name: Secret name.
+            namespace: Target namespace.
+
+        Returns:
+            Secret summary (no secret values).
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_secret", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_secret(name=name, namespace=ns)
+            return SecretSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Secret", name, ns)
+
+    def create_secret(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        data: dict[str, str] | None = None,
+        secret_type: str = "Opaque",
+        labels: dict[str, str] | None = None,
+    ) -> SecretSummary:
+        """Create a secret.
+
+        Args:
+            name: Secret name.
+            namespace: Target namespace.
+            data: Key-value pairs (values will be base64-encoded).
+            secret_type: Secret type (Opaque, kubernetes.io/tls, etc.).
+            labels: Secret labels.
+
+        Returns:
+            Created secret summary.
+        """
+        from kubernetes.client import V1ObjectMeta, V1Secret
+
+        ns = self._resolve_namespace(namespace)
+
+        # Base64-encode string values
+        encoded_data = None
+        if data:
+            encoded_data = {k: base64.b64encode(v.encode()).decode() for k, v in data.items()}
+
+        body = V1Secret(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            type=secret_type,
+            data=encoded_data,
+        )
+
+        self._log.info("creating_secret", name=name, namespace=ns, type=secret_type)
+        try:
+            result = self._client.core_v1.create_namespaced_secret(namespace=ns, body=body)
+            self._log.info("created_secret", name=name, namespace=ns)
+            return SecretSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Secret", name, ns)
+
+    def create_tls_secret(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        cert: str,
+        key: str,
+        labels: dict[str, str] | None = None,
+    ) -> SecretSummary:
+        """Create a TLS secret.
+
+        Args:
+            name: Secret name.
+            namespace: Target namespace.
+            cert: PEM-encoded certificate.
+            key: PEM-encoded private key.
+            labels: Secret labels.
+
+        Returns:
+            Created secret summary.
+        """
+        from kubernetes.client import V1ObjectMeta, V1Secret
+
+        ns = self._resolve_namespace(namespace)
+
+        body = V1Secret(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            type="kubernetes.io/tls",
+            data={
+                "tls.crt": base64.b64encode(cert.encode()).decode(),
+                "tls.key": base64.b64encode(key.encode()).decode(),
+            },
+        )
+
+        self._log.info("creating_tls_secret", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.create_namespaced_secret(namespace=ns, body=body)
+            self._log.info("created_tls_secret", name=name, namespace=ns)
+            return SecretSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Secret", name, ns)
+
+    def create_docker_registry_secret(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        server: str,
+        username: str,
+        password: str,
+        email: str = "",
+        labels: dict[str, str] | None = None,
+    ) -> SecretSummary:
+        """Create a docker-registry secret.
+
+        Args:
+            name: Secret name.
+            namespace: Target namespace.
+            server: Docker registry server URL.
+            username: Registry username.
+            password: Registry password.
+            email: Registry email.
+            labels: Secret labels.
+
+        Returns:
+            Created secret summary.
+        """
+        from kubernetes.client import V1ObjectMeta, V1Secret
+
+        ns = self._resolve_namespace(namespace)
+
+        docker_config = {
+            "auths": {
+                server: {
+                    "username": username,
+                    "password": password,
+                    "email": email,
+                    "auth": base64.b64encode(f"{username}:{password}".encode()).decode(),
+                }
+            }
+        }
+
+        body = V1Secret(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            type="kubernetes.io/dockerconfigjson",
+            data={
+                ".dockerconfigjson": base64.b64encode(json.dumps(docker_config).encode()).decode(),
+            },
+        )
+
+        self._log.info("creating_docker_registry_secret", name=name, namespace=ns, server=server)
+        try:
+            result = self._client.core_v1.create_namespaced_secret(namespace=ns, body=body)
+            self._log.info("created_docker_registry_secret", name=name, namespace=ns)
+            return SecretSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Secret", name, ns)
+
+    def delete_secret(self, name: str, namespace: str | None = None) -> None:
+        """Delete a secret.
+
+        Args:
+            name: Secret name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_secret", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_secret(name=name, namespace=ns)
+            self._log.info("deleted_secret", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Secret", name, ns)

--- a/src/system_operations_manager/services/kubernetes/job_manager.py
+++ b/src/system_operations_manager/services/kubernetes/job_manager.py
@@ -1,0 +1,379 @@
+"""Kubernetes job resource manager.
+
+Manages Jobs and CronJobs through the Kubernetes API,
+including suspend/resume operations for CronJobs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.jobs import (
+    CronJobSummary,
+    JobSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class JobManager(K8sBaseManager):
+    """Manager for Kubernetes job resources.
+
+    Provides CRUD operations for Jobs and CronJobs,
+    plus suspend/resume for CronJobs.
+    """
+
+    _entity_name = "job"
+
+    # =========================================================================
+    # Job Operations
+    # =========================================================================
+
+    def list_jobs(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[JobSummary]:
+        """List jobs.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of job summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_jobs", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.batch_v1.list_job_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.batch_v1.list_namespaced_job(namespace=ns, **kwargs)
+
+            items = [JobSummary.from_k8s_object(j) for j in result.items]
+            self._log.debug("listed_jobs", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Job", None, ns)
+
+    def get_job(self, name: str, namespace: str | None = None) -> JobSummary:
+        """Get a single job by name.
+
+        Args:
+            name: Job name.
+            namespace: Target namespace.
+
+        Returns:
+            Job summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_job", name=name, namespace=ns)
+        try:
+            result = self._client.batch_v1.read_namespaced_job(name=name, namespace=ns)
+            return JobSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Job", name, ns)
+
+    def create_job(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str,
+        command: list[str] | None = None,
+        completions: int = 1,
+        parallelism: int = 1,
+        labels: dict[str, str] | None = None,
+    ) -> JobSummary:
+        """Create a job.
+
+        Args:
+            name: Job name.
+            namespace: Target namespace.
+            image: Container image.
+            command: Container command.
+            completions: Number of successful completions needed.
+            parallelism: Number of pods to run in parallel.
+            labels: Job labels.
+
+        Returns:
+            Created job summary.
+        """
+        from kubernetes.client import (
+            V1Container,
+            V1Job,
+            V1JobSpec,
+            V1ObjectMeta,
+            V1PodSpec,
+            V1PodTemplateSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        pod_labels = labels or {"job-name": name}
+
+        container = V1Container(
+            name=name,
+            image=image,
+            command=command,
+        )
+
+        body = V1Job(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=pod_labels),
+            spec=V1JobSpec(
+                completions=completions,
+                parallelism=parallelism,
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(labels=pod_labels),
+                    spec=V1PodSpec(
+                        containers=[container],
+                        restart_policy="Never",
+                    ),
+                ),
+            ),
+        )
+
+        self._log.info("creating_job", name=name, namespace=ns, image=image)
+        try:
+            result = self._client.batch_v1.create_namespaced_job(namespace=ns, body=body)
+            self._log.info("created_job", name=name, namespace=ns)
+            return JobSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Job", name, ns)
+
+    def delete_job(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        propagation_policy: str = "Background",
+    ) -> None:
+        """Delete a job.
+
+        Args:
+            name: Job name.
+            namespace: Target namespace.
+            propagation_policy: Deletion propagation (Background, Foreground, Orphan).
+        """
+        from kubernetes.client import V1DeleteOptions
+
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_job", name=name, namespace=ns)
+        try:
+            self._client.batch_v1.delete_namespaced_job(
+                name=name,
+                namespace=ns,
+                body=V1DeleteOptions(propagation_policy=propagation_policy),
+            )
+            self._log.info("deleted_job", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Job", name, ns)
+
+    # =========================================================================
+    # CronJob Operations
+    # =========================================================================
+
+    def list_cron_jobs(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[CronJobSummary]:
+        """List cronjobs.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of cronjob summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_cronjobs", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.batch_v1.list_cron_job_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.batch_v1.list_namespaced_cron_job(namespace=ns, **kwargs)
+
+            items = [CronJobSummary.from_k8s_object(cj) for cj in result.items]
+            self._log.debug("listed_cronjobs", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "CronJob", None, ns)
+
+    def get_cron_job(self, name: str, namespace: str | None = None) -> CronJobSummary:
+        """Get a single cronjob by name.
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+
+        Returns:
+            CronJob summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_cronjob", name=name, namespace=ns)
+        try:
+            result = self._client.batch_v1.read_namespaced_cron_job(name=name, namespace=ns)
+            return CronJobSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "CronJob", name, ns)
+
+    def create_cron_job(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str,
+        command: list[str] | None = None,
+        schedule: str,
+        labels: dict[str, str] | None = None,
+    ) -> CronJobSummary:
+        """Create a cronjob.
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+            image: Container image.
+            command: Container command.
+            schedule: Cron schedule expression (e.g., '*/5 * * * *').
+            labels: CronJob labels.
+
+        Returns:
+            Created cronjob summary.
+        """
+        from kubernetes.client import (
+            V1Container,
+            V1CronJob,
+            V1CronJobSpec,
+            V1JobSpec,
+            V1JobTemplateSpec,
+            V1ObjectMeta,
+            V1PodSpec,
+            V1PodTemplateSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        pod_labels = labels or {"cronjob-name": name}
+
+        container = V1Container(
+            name=name,
+            image=image,
+            command=command,
+        )
+
+        body = V1CronJob(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=pod_labels),
+            spec=V1CronJobSpec(
+                schedule=schedule,
+                job_template=V1JobTemplateSpec(
+                    spec=V1JobSpec(
+                        template=V1PodTemplateSpec(
+                            metadata=V1ObjectMeta(labels=pod_labels),
+                            spec=V1PodSpec(
+                                containers=[container],
+                                restart_policy="Never",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self._log.info("creating_cronjob", name=name, namespace=ns, schedule=schedule)
+        try:
+            result = self._client.batch_v1.create_namespaced_cron_job(namespace=ns, body=body)
+            self._log.info("created_cronjob", name=name, namespace=ns)
+            return CronJobSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "CronJob", name, ns)
+
+    def update_cron_job(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        schedule: str | None = None,
+        suspend: bool | None = None,
+    ) -> CronJobSummary:
+        """Update a cronjob (patch).
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+            schedule: New cron schedule.
+            suspend: Whether to suspend the cronjob.
+
+        Returns:
+            Updated cronjob summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_cronjob", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if schedule is not None:
+                patch["spec"]["schedule"] = schedule
+            if suspend is not None:
+                patch["spec"]["suspend"] = suspend
+
+            result = self._client.batch_v1.patch_namespaced_cron_job(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_cronjob", name=name, namespace=ns)
+            return CronJobSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "CronJob", name, ns)
+
+    def delete_cron_job(self, name: str, namespace: str | None = None) -> None:
+        """Delete a cronjob.
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_cronjob", name=name, namespace=ns)
+        try:
+            self._client.batch_v1.delete_namespaced_cron_job(name=name, namespace=ns)
+            self._log.info("deleted_cronjob", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "CronJob", name, ns)
+
+    def suspend_cron_job(self, name: str, namespace: str | None = None) -> CronJobSummary:
+        """Suspend a cronjob.
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+
+        Returns:
+            Updated cronjob summary.
+        """
+        self._log.info("suspending_cronjob", name=name)
+        return self.update_cron_job(name, namespace, suspend=True)
+
+    def resume_cron_job(self, name: str, namespace: str | None = None) -> CronJobSummary:
+        """Resume a suspended cronjob.
+
+        Args:
+            name: CronJob name.
+            namespace: Target namespace.
+
+        Returns:
+            Updated cronjob summary.
+        """
+        self._log.info("resuming_cronjob", name=name)
+        return self.update_cron_job(name, namespace, suspend=False)

--- a/src/system_operations_manager/services/kubernetes/namespace_manager.py
+++ b/src/system_operations_manager/services/kubernetes/namespace_manager.py
@@ -1,0 +1,242 @@
+"""Kubernetes namespace and cluster resource manager.
+
+Manages Namespaces, Nodes, Events, and cluster-level information
+through the Kubernetes API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.cluster import (
+    EventSummary,
+    NamespaceSummary,
+    NodeSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class NamespaceClusterManager(K8sBaseManager):
+    """Manager for Kubernetes namespace and cluster resources.
+
+    Provides operations for Namespaces, Nodes, Events, and cluster information.
+    """
+
+    _entity_name = "namespace_cluster"
+
+    # =========================================================================
+    # Namespace Operations
+    # =========================================================================
+
+    def list_namespaces(
+        self,
+        *,
+        label_selector: str | None = None,
+    ) -> list[NamespaceSummary]:
+        """List all namespaces.
+
+        Args:
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of namespace summaries.
+        """
+        self._log.debug("listing_namespaces")
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.core_v1.list_namespace(**kwargs)
+            items = [NamespaceSummary.from_k8s_object(ns) for ns in result.items]
+            self._log.debug("listed_namespaces", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Namespace", None, None)
+
+    def get_namespace(self, name: str) -> NamespaceSummary:
+        """Get a single namespace by name.
+
+        Args:
+            name: Namespace name.
+
+        Returns:
+            Namespace summary.
+        """
+        self._log.debug("getting_namespace", name=name)
+        try:
+            result = self._client.core_v1.read_namespace(name=name)
+            return NamespaceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Namespace", name, None)
+
+    def create_namespace(
+        self,
+        name: str,
+        *,
+        labels: dict[str, str] | None = None,
+    ) -> NamespaceSummary:
+        """Create a namespace.
+
+        Args:
+            name: Namespace name.
+            labels: Namespace labels.
+
+        Returns:
+            Created namespace summary.
+        """
+        from kubernetes.client import V1Namespace, V1ObjectMeta
+
+        body = V1Namespace(
+            metadata=V1ObjectMeta(name=name, labels=labels),
+        )
+
+        self._log.info("creating_namespace", name=name)
+        try:
+            result = self._client.core_v1.create_namespace(body=body)
+            self._log.info("created_namespace", name=name)
+            return NamespaceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Namespace", name, None)
+
+    def delete_namespace(self, name: str) -> None:
+        """Delete a namespace.
+
+        Args:
+            name: Namespace name.
+        """
+        self._log.info("deleting_namespace", name=name)
+        try:
+            self._client.core_v1.delete_namespace(name=name)
+            self._log.info("deleted_namespace", name=name)
+        except Exception as e:
+            self._handle_api_error(e, "Namespace", name, None)
+
+    # =========================================================================
+    # Node Operations
+    # =========================================================================
+
+    def list_nodes(
+        self,
+        *,
+        label_selector: str | None = None,
+    ) -> list[NodeSummary]:
+        """List all nodes.
+
+        Args:
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of node summaries.
+        """
+        self._log.debug("listing_nodes")
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.core_v1.list_node(**kwargs)
+            items = [NodeSummary.from_k8s_object(node) for node in result.items]
+            self._log.debug("listed_nodes", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Node", None, None)
+
+    def get_node(self, name: str) -> NodeSummary:
+        """Get a single node by name.
+
+        Args:
+            name: Node name.
+
+        Returns:
+            Node summary.
+        """
+        self._log.debug("getting_node", name=name)
+        try:
+            result = self._client.core_v1.read_node(name=name)
+            return NodeSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Node", name, None)
+
+    # =========================================================================
+    # Event Operations
+    # =========================================================================
+
+    def list_events(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        field_selector: str | None = None,
+        involved_object: str | None = None,
+    ) -> list[EventSummary]:
+        """List events.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            field_selector: Filter by field selector.
+            involved_object: Filter by involved object name
+                (adds involvedObject.name field selector).
+
+        Returns:
+            List of event summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_events", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+
+            selectors = []
+            if field_selector:
+                selectors.append(field_selector)
+            if involved_object:
+                selectors.append(f"involvedObject.name={involved_object}")
+            if selectors:
+                kwargs["field_selector"] = ",".join(selectors)
+
+            if all_namespaces:
+                result = self._client.core_v1.list_event_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_event(namespace=ns, **kwargs)
+
+            items = [EventSummary.from_k8s_object(evt) for evt in result.items]
+            self._log.debug("listed_events", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Event", None, ns)
+
+    # =========================================================================
+    # Cluster Info
+    # =========================================================================
+
+    def get_cluster_info(self) -> dict[str, Any]:
+        """Get cluster information summary.
+
+        Returns:
+            Dictionary with cluster version, node count, and namespace count.
+        """
+        self._log.debug("getting_cluster_info")
+        info: dict[str, Any] = {}
+
+        try:
+            info["version"] = self._client.get_cluster_version()
+        except Exception:
+            info["version"] = "unknown"
+
+        try:
+            nodes = self._client.core_v1.list_node()
+            info["node_count"] = len(nodes.items) if nodes.items else 0
+        except Exception:
+            info["node_count"] = "unknown"
+
+        try:
+            namespaces = self._client.core_v1.list_namespace()
+            info["namespace_count"] = len(namespaces.items) if namespaces.items else 0
+        except Exception:
+            info["namespace_count"] = "unknown"
+
+        info["context"] = self._client.get_current_context()
+        info["default_namespace"] = self._client.default_namespace
+
+        return info

--- a/src/system_operations_manager/services/kubernetes/networking_manager.py
+++ b/src/system_operations_manager/services/kubernetes/networking_manager.py
@@ -1,0 +1,559 @@
+"""Kubernetes networking resource manager.
+
+Manages Services, Ingresses, and NetworkPolicies through the Kubernetes API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.networking import (
+    IngressSummary,
+    NetworkPolicySummary,
+    ServiceSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class NetworkingManager(K8sBaseManager):
+    """Manager for Kubernetes networking resources.
+
+    Provides CRUD operations for Services, Ingresses, and NetworkPolicies.
+    """
+
+    _entity_name = "networking"
+
+    # =========================================================================
+    # Service Operations
+    # =========================================================================
+
+    def list_services(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[ServiceSummary]:
+        """List services.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of service summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_services", namespace=ns, all_namespaces=all_namespaces)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_service_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_service(namespace=ns, **kwargs)
+
+            services = [ServiceSummary.from_k8s_object(svc) for svc in result.items]
+            self._log.debug("listed_services", count=len(services))
+            return services
+        except Exception as e:
+            self._handle_api_error(e, "Service", None, ns)
+
+    def get_service(self, name: str, namespace: str | None = None) -> ServiceSummary:
+        """Get a single service by name.
+
+        Args:
+            name: Service name.
+            namespace: Target namespace.
+
+        Returns:
+            Service summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_service", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_service(name=name, namespace=ns)
+            return ServiceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Service", name, ns)
+
+    def create_service(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        type: str = "ClusterIP",
+        selector: dict[str, str] | None = None,
+        ports: list[dict[str, Any]] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> ServiceSummary:
+        """Create a service.
+
+        Args:
+            name: Service name.
+            namespace: Target namespace.
+            type: Service type (ClusterIP, NodePort, LoadBalancer, ExternalName).
+            selector: Pod selector labels.
+            ports: List of port definitions (each with 'port', 'target_port', 'protocol').
+            labels: Service labels.
+
+        Returns:
+            Created service summary.
+        """
+        from kubernetes.client import (
+            V1ObjectMeta,
+            V1Service,
+            V1ServicePort,
+            V1ServiceSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+
+        svc_ports = []
+        for p in ports or []:
+            svc_ports.append(
+                V1ServicePort(
+                    port=p["port"],
+                    target_port=p.get("target_port"),
+                    protocol=p.get("protocol", "TCP"),
+                    name=p.get("name"),
+                )
+            )
+
+        body = V1Service(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            spec=V1ServiceSpec(
+                type=type,
+                selector=selector,
+                ports=svc_ports or None,
+            ),
+        )
+
+        self._log.info("creating_service", name=name, namespace=ns, type=type)
+        try:
+            result = self._client.core_v1.create_namespaced_service(namespace=ns, body=body)
+            self._log.info("created_service", name=name, namespace=ns)
+            return ServiceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Service", name, ns)
+
+    def update_service(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        type: str | None = None,
+        selector: dict[str, str] | None = None,
+        ports: list[dict[str, Any]] | None = None,
+    ) -> ServiceSummary:
+        """Update a service (patch).
+
+        Args:
+            name: Service name.
+            namespace: Target namespace.
+            type: New service type.
+            selector: New pod selector.
+            ports: New port definitions.
+
+        Returns:
+            Updated service summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_service", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if type is not None:
+                patch["spec"]["type"] = type
+            if selector is not None:
+                patch["spec"]["selector"] = selector
+            if ports is not None:
+                patch["spec"]["ports"] = [
+                    {
+                        "port": p["port"],
+                        "targetPort": p.get("target_port"),
+                        "protocol": p.get("protocol", "TCP"),
+                        "name": p.get("name"),
+                    }
+                    for p in ports
+                ]
+
+            result = self._client.core_v1.patch_namespaced_service(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_service", name=name, namespace=ns)
+            return ServiceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Service", name, ns)
+
+    def delete_service(self, name: str, namespace: str | None = None) -> None:
+        """Delete a service.
+
+        Args:
+            name: Service name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_service", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_service(name=name, namespace=ns)
+            self._log.info("deleted_service", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Service", name, ns)
+
+    # =========================================================================
+    # Ingress Operations
+    # =========================================================================
+
+    def list_ingresses(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[IngressSummary]:
+        """List ingresses.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of ingress summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_ingresses", namespace=ns, all_namespaces=all_namespaces)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.networking_v1.list_ingress_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.networking_v1.list_namespaced_ingress(namespace=ns, **kwargs)
+
+            items = [IngressSummary.from_k8s_object(ing) for ing in result.items]
+            self._log.debug("listed_ingresses", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Ingress", None, ns)
+
+    def get_ingress(self, name: str, namespace: str | None = None) -> IngressSummary:
+        """Get a single ingress by name.
+
+        Args:
+            name: Ingress name.
+            namespace: Target namespace.
+
+        Returns:
+            Ingress summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_ingress", name=name, namespace=ns)
+        try:
+            result = self._client.networking_v1.read_namespaced_ingress(name=name, namespace=ns)
+            return IngressSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Ingress", name, ns)
+
+    def create_ingress(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        class_name: str | None = None,
+        rules: list[dict[str, Any]] | None = None,
+        tls: list[dict[str, Any]] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> IngressSummary:
+        """Create an ingress.
+
+        Args:
+            name: Ingress name.
+            namespace: Target namespace.
+            class_name: Ingress class name (e.g., 'nginx').
+            rules: List of ingress rules, each with 'host' and 'paths'.
+                Each path has 'path', 'path_type', 'service_name', 'service_port'.
+            tls: List of TLS configs, each with 'hosts' and 'secret_name'.
+            labels: Ingress labels.
+
+        Returns:
+            Created ingress summary.
+        """
+        from kubernetes.client import (
+            V1HTTPIngressPath,
+            V1HTTPIngressRuleValue,
+            V1Ingress,
+            V1IngressBackend,
+            V1IngressRule,
+            V1IngressServiceBackend,
+            V1IngressSpec,
+            V1IngressTLS,
+            V1ObjectMeta,
+            V1ServiceBackendPort,
+        )
+
+        ns = self._resolve_namespace(namespace)
+
+        ingress_rules = []
+        for rule in rules or []:
+            paths = []
+            for p in rule.get("paths", []):
+                paths.append(
+                    V1HTTPIngressPath(
+                        path=p.get("path", "/"),
+                        path_type=p.get("path_type", "Prefix"),
+                        backend=V1IngressBackend(
+                            service=V1IngressServiceBackend(
+                                name=p["service_name"],
+                                port=V1ServiceBackendPort(
+                                    number=p.get("service_port"),
+                                ),
+                            )
+                        ),
+                    )
+                )
+            ingress_rules.append(
+                V1IngressRule(
+                    host=rule.get("host"),
+                    http=V1HTTPIngressRuleValue(paths=paths) if paths else None,
+                )
+            )
+
+        ingress_tls = None
+        if tls:
+            ingress_tls = [
+                V1IngressTLS(
+                    hosts=t.get("hosts", []),
+                    secret_name=t.get("secret_name"),
+                )
+                for t in tls
+            ]
+
+        body = V1Ingress(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            spec=V1IngressSpec(
+                ingress_class_name=class_name,
+                rules=ingress_rules or None,
+                tls=ingress_tls,
+            ),
+        )
+
+        self._log.info("creating_ingress", name=name, namespace=ns)
+        try:
+            result = self._client.networking_v1.create_namespaced_ingress(namespace=ns, body=body)
+            self._log.info("created_ingress", name=name, namespace=ns)
+            return IngressSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Ingress", name, ns)
+
+    def update_ingress(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        class_name: str | None = None,
+        rules: list[dict[str, Any]] | None = None,
+        tls: list[dict[str, Any]] | None = None,
+    ) -> IngressSummary:
+        """Update an ingress (patch).
+
+        Args:
+            name: Ingress name.
+            namespace: Target namespace.
+            class_name: New ingress class name.
+            rules: New ingress rules.
+            tls: New TLS configuration.
+
+        Returns:
+            Updated ingress summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_ingress", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if class_name is not None:
+                patch["spec"]["ingressClassName"] = class_name
+            if rules is not None:
+                patch["spec"]["rules"] = [
+                    {
+                        "host": r.get("host"),
+                        "http": {
+                            "paths": [
+                                {
+                                    "path": p.get("path", "/"),
+                                    "pathType": p.get("path_type", "Prefix"),
+                                    "backend": {
+                                        "service": {
+                                            "name": p["service_name"],
+                                            "port": {"number": p.get("service_port")},
+                                        }
+                                    },
+                                }
+                                for p in r.get("paths", [])
+                            ]
+                        },
+                    }
+                    for r in rules
+                ]
+            if tls is not None:
+                patch["spec"]["tls"] = [
+                    {"hosts": t.get("hosts", []), "secretName": t.get("secret_name")} for t in tls
+                ]
+
+            result = self._client.networking_v1.patch_namespaced_ingress(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_ingress", name=name, namespace=ns)
+            return IngressSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Ingress", name, ns)
+
+    def delete_ingress(self, name: str, namespace: str | None = None) -> None:
+        """Delete an ingress.
+
+        Args:
+            name: Ingress name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_ingress", name=name, namespace=ns)
+        try:
+            self._client.networking_v1.delete_namespaced_ingress(name=name, namespace=ns)
+            self._log.info("deleted_ingress", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Ingress", name, ns)
+
+    # =========================================================================
+    # NetworkPolicy Operations
+    # =========================================================================
+
+    def list_network_policies(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[NetworkPolicySummary]:
+        """List network policies.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of network policy summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_network_policies", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.networking_v1.list_network_policy_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.networking_v1.list_namespaced_network_policy(
+                    namespace=ns, **kwargs
+                )
+
+            items = [NetworkPolicySummary.from_k8s_object(np) for np in result.items]
+            self._log.debug("listed_network_policies", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "NetworkPolicy", None, ns)
+
+    def get_network_policy(self, name: str, namespace: str | None = None) -> NetworkPolicySummary:
+        """Get a single network policy by name.
+
+        Args:
+            name: NetworkPolicy name.
+            namespace: Target namespace.
+
+        Returns:
+            NetworkPolicy summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_network_policy", name=name, namespace=ns)
+        try:
+            result = self._client.networking_v1.read_namespaced_network_policy(
+                name=name, namespace=ns
+            )
+            return NetworkPolicySummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "NetworkPolicy", name, ns)
+
+    def create_network_policy(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        pod_selector: dict[str, str] | None = None,
+        policy_types: list[str] | None = None,
+        ingress_rules: list[dict[str, Any]] | None = None,
+        egress_rules: list[dict[str, Any]] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> NetworkPolicySummary:
+        """Create a network policy.
+
+        Args:
+            name: NetworkPolicy name.
+            namespace: Target namespace.
+            pod_selector: Pod selector match labels.
+            policy_types: Policy types (Ingress, Egress).
+            ingress_rules: Ingress rule definitions.
+            egress_rules: Egress rule definitions.
+            labels: NetworkPolicy labels.
+
+        Returns:
+            Created network policy summary.
+        """
+        from kubernetes.client import (
+            V1LabelSelector,
+            V1NetworkPolicy,
+            V1NetworkPolicySpec,
+            V1ObjectMeta,
+        )
+
+        ns = self._resolve_namespace(namespace)
+
+        body = V1NetworkPolicy(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            spec=V1NetworkPolicySpec(
+                pod_selector=V1LabelSelector(match_labels=pod_selector or {}),
+                policy_types=policy_types,
+                ingress=ingress_rules,
+                egress=egress_rules,
+            ),
+        )
+
+        self._log.info("creating_network_policy", name=name, namespace=ns)
+        try:
+            result = self._client.networking_v1.create_namespaced_network_policy(
+                namespace=ns, body=body
+            )
+            self._log.info("created_network_policy", name=name, namespace=ns)
+            return NetworkPolicySummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "NetworkPolicy", name, ns)
+
+    def delete_network_policy(self, name: str, namespace: str | None = None) -> None:
+        """Delete a network policy.
+
+        Args:
+            name: NetworkPolicy name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_network_policy", name=name, namespace=ns)
+        try:
+            self._client.networking_v1.delete_namespaced_network_policy(name=name, namespace=ns)
+            self._log.info("deleted_network_policy", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "NetworkPolicy", name, ns)

--- a/src/system_operations_manager/services/kubernetes/rbac_manager.py
+++ b/src/system_operations_manager/services/kubernetes/rbac_manager.py
@@ -1,0 +1,582 @@
+"""Kubernetes RBAC resource manager.
+
+Manages ServiceAccounts, Roles, ClusterRoles, RoleBindings,
+and ClusterRoleBindings through the Kubernetes API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.rbac import (
+    RoleBindingSummary,
+    RoleSummary,
+    ServiceAccountSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class RBACManager(K8sBaseManager):
+    """Manager for Kubernetes RBAC resources.
+
+    Provides CRUD operations for ServiceAccounts, Roles, ClusterRoles,
+    RoleBindings, and ClusterRoleBindings.
+    """
+
+    _entity_name = "rbac"
+
+    # =========================================================================
+    # ServiceAccount Operations
+    # =========================================================================
+
+    def list_service_accounts(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[ServiceAccountSummary]:
+        """List service accounts.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of service account summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_service_accounts", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_service_account_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_service_account(
+                    namespace=ns, **kwargs
+                )
+
+            items = [ServiceAccountSummary.from_k8s_object(sa) for sa in result.items]
+            self._log.debug("listed_service_accounts", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "ServiceAccount", None, ns)
+
+    def get_service_account(self, name: str, namespace: str | None = None) -> ServiceAccountSummary:
+        """Get a single service account by name.
+
+        Args:
+            name: ServiceAccount name.
+            namespace: Target namespace.
+
+        Returns:
+            ServiceAccount summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_service_account", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_service_account(name=name, namespace=ns)
+            return ServiceAccountSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ServiceAccount", name, ns)
+
+    def create_service_account(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        labels: dict[str, str] | None = None,
+    ) -> ServiceAccountSummary:
+        """Create a service account.
+
+        Args:
+            name: ServiceAccount name.
+            namespace: Target namespace.
+            labels: ServiceAccount labels.
+
+        Returns:
+            Created service account summary.
+        """
+        from kubernetes.client import V1ObjectMeta, V1ServiceAccount
+
+        ns = self._resolve_namespace(namespace)
+
+        body = V1ServiceAccount(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+        )
+
+        self._log.info("creating_service_account", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.create_namespaced_service_account(namespace=ns, body=body)
+            self._log.info("created_service_account", name=name, namespace=ns)
+            return ServiceAccountSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ServiceAccount", name, ns)
+
+    def delete_service_account(self, name: str, namespace: str | None = None) -> None:
+        """Delete a service account.
+
+        Args:
+            name: ServiceAccount name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_service_account", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_service_account(name=name, namespace=ns)
+            self._log.info("deleted_service_account", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "ServiceAccount", name, ns)
+
+    # =========================================================================
+    # Role Operations (Namespaced)
+    # =========================================================================
+
+    def list_roles(
+        self,
+        namespace: str | None = None,
+        *,
+        label_selector: str | None = None,
+    ) -> list[RoleSummary]:
+        """List roles in a namespace.
+
+        Args:
+            namespace: Target namespace.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of role summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_roles", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.rbac_v1.list_namespaced_role(namespace=ns, **kwargs)
+            items = [RoleSummary.from_k8s_object(r) for r in result.items]
+            self._log.debug("listed_roles", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "Role", None, ns)
+
+    def get_role(self, name: str, namespace: str | None = None) -> RoleSummary:
+        """Get a single role by name.
+
+        Args:
+            name: Role name.
+            namespace: Target namespace.
+
+        Returns:
+            Role summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_role", name=name, namespace=ns)
+        try:
+            result = self._client.rbac_v1.read_namespaced_role(name=name, namespace=ns)
+            return RoleSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Role", name, ns)
+
+    def create_role(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        rules: list[dict[str, Any]] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> RoleSummary:
+        """Create a role.
+
+        Args:
+            name: Role name.
+            namespace: Target namespace.
+            rules: List of policy rules, each with 'verbs', 'api_groups', 'resources'.
+            labels: Role labels.
+
+        Returns:
+            Created role summary.
+        """
+        from kubernetes.client import V1ObjectMeta, V1PolicyRule, V1Role
+
+        ns = self._resolve_namespace(namespace)
+
+        policy_rules = [
+            V1PolicyRule(
+                verbs=r.get("verbs", []),
+                api_groups=r.get("api_groups", [""]),
+                resources=r.get("resources", []),
+                resource_names=r.get("resource_names"),
+            )
+            for r in (rules or [])
+        ]
+
+        body = V1Role(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            rules=policy_rules or None,
+        )
+
+        self._log.info("creating_role", name=name, namespace=ns)
+        try:
+            result = self._client.rbac_v1.create_namespaced_role(namespace=ns, body=body)
+            self._log.info("created_role", name=name, namespace=ns)
+            return RoleSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Role", name, ns)
+
+    def delete_role(self, name: str, namespace: str | None = None) -> None:
+        """Delete a role.
+
+        Args:
+            name: Role name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_role", name=name, namespace=ns)
+        try:
+            self._client.rbac_v1.delete_namespaced_role(name=name, namespace=ns)
+            self._log.info("deleted_role", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Role", name, ns)
+
+    # =========================================================================
+    # ClusterRole Operations (Cluster-Scoped)
+    # =========================================================================
+
+    def list_cluster_roles(
+        self,
+        *,
+        label_selector: str | None = None,
+    ) -> list[RoleSummary]:
+        """List cluster roles.
+
+        Args:
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of role summaries (with is_cluster_role=True).
+        """
+        self._log.debug("listing_cluster_roles")
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.rbac_v1.list_cluster_role(**kwargs)
+            items = [RoleSummary.from_k8s_object(r, is_cluster_role=True) for r in result.items]
+            self._log.debug("listed_cluster_roles", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRole", None, None)
+
+    def get_cluster_role(self, name: str) -> RoleSummary:
+        """Get a single cluster role by name.
+
+        Args:
+            name: ClusterRole name.
+
+        Returns:
+            Role summary (with is_cluster_role=True).
+        """
+        self._log.debug("getting_cluster_role", name=name)
+        try:
+            result = self._client.rbac_v1.read_cluster_role(name=name)
+            return RoleSummary.from_k8s_object(result, is_cluster_role=True)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRole", name, None)
+
+    def create_cluster_role(
+        self,
+        name: str,
+        *,
+        rules: list[dict[str, Any]] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> RoleSummary:
+        """Create a cluster role.
+
+        Args:
+            name: ClusterRole name.
+            rules: List of policy rules.
+            labels: ClusterRole labels.
+
+        Returns:
+            Created role summary (with is_cluster_role=True).
+        """
+        from kubernetes.client import V1ClusterRole, V1ObjectMeta, V1PolicyRule
+
+        policy_rules = [
+            V1PolicyRule(
+                verbs=r.get("verbs", []),
+                api_groups=r.get("api_groups", [""]),
+                resources=r.get("resources", []),
+                resource_names=r.get("resource_names"),
+            )
+            for r in (rules or [])
+        ]
+
+        body = V1ClusterRole(
+            metadata=V1ObjectMeta(name=name, labels=labels),
+            rules=policy_rules or None,
+        )
+
+        self._log.info("creating_cluster_role", name=name)
+        try:
+            result = self._client.rbac_v1.create_cluster_role(body=body)
+            self._log.info("created_cluster_role", name=name)
+            return RoleSummary.from_k8s_object(result, is_cluster_role=True)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRole", name, None)
+
+    def delete_cluster_role(self, name: str) -> None:
+        """Delete a cluster role.
+
+        Args:
+            name: ClusterRole name.
+        """
+        self._log.info("deleting_cluster_role", name=name)
+        try:
+            self._client.rbac_v1.delete_cluster_role(name=name)
+            self._log.info("deleted_cluster_role", name=name)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRole", name, None)
+
+    # =========================================================================
+    # RoleBinding Operations (Namespaced)
+    # =========================================================================
+
+    def list_role_bindings(
+        self,
+        namespace: str | None = None,
+        *,
+        label_selector: str | None = None,
+    ) -> list[RoleBindingSummary]:
+        """List role bindings in a namespace.
+
+        Args:
+            namespace: Target namespace.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of role binding summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_role_bindings", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.rbac_v1.list_namespaced_role_binding(namespace=ns, **kwargs)
+            items = [RoleBindingSummary.from_k8s_object(rb) for rb in result.items]
+            self._log.debug("listed_role_bindings", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "RoleBinding", None, ns)
+
+    def get_role_binding(self, name: str, namespace: str | None = None) -> RoleBindingSummary:
+        """Get a single role binding by name.
+
+        Args:
+            name: RoleBinding name.
+            namespace: Target namespace.
+
+        Returns:
+            RoleBinding summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_role_binding", name=name, namespace=ns)
+        try:
+            result = self._client.rbac_v1.read_namespaced_role_binding(name=name, namespace=ns)
+            return RoleBindingSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "RoleBinding", name, ns)
+
+    def create_role_binding(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        role_ref: dict[str, str],
+        subjects: list[dict[str, str]],
+        labels: dict[str, str] | None = None,
+    ) -> RoleBindingSummary:
+        """Create a role binding.
+
+        Args:
+            name: RoleBinding name.
+            namespace: Target namespace.
+            role_ref: Role reference with 'kind' (Role/ClusterRole), 'name', 'api_group'.
+            subjects: List of subjects, each with 'kind', 'name', 'namespace' (optional).
+            labels: RoleBinding labels.
+
+        Returns:
+            Created role binding summary.
+        """
+        from kubernetes.client import (
+            V1ObjectMeta,
+            V1RoleBinding,
+            V1RoleRef,
+            V1Subject,
+        )
+
+        ns = self._resolve_namespace(namespace)
+
+        body = V1RoleBinding(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            role_ref=V1RoleRef(
+                kind=role_ref.get("kind", "Role"),
+                name=role_ref["name"],
+                api_group=role_ref.get("api_group", "rbac.authorization.k8s.io"),
+            ),
+            subjects=[
+                V1Subject(
+                    kind=s.get("kind", "ServiceAccount"),
+                    name=s["name"],
+                    namespace=s.get("namespace"),
+                    api_group=s.get("api_group"),
+                )
+                for s in subjects
+            ],
+        )
+
+        self._log.info("creating_role_binding", name=name, namespace=ns)
+        try:
+            result = self._client.rbac_v1.create_namespaced_role_binding(namespace=ns, body=body)
+            self._log.info("created_role_binding", name=name, namespace=ns)
+            return RoleBindingSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "RoleBinding", name, ns)
+
+    def delete_role_binding(self, name: str, namespace: str | None = None) -> None:
+        """Delete a role binding.
+
+        Args:
+            name: RoleBinding name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_role_binding", name=name, namespace=ns)
+        try:
+            self._client.rbac_v1.delete_namespaced_role_binding(name=name, namespace=ns)
+            self._log.info("deleted_role_binding", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "RoleBinding", name, ns)
+
+    # =========================================================================
+    # ClusterRoleBinding Operations (Cluster-Scoped)
+    # =========================================================================
+
+    def list_cluster_role_bindings(
+        self,
+        *,
+        label_selector: str | None = None,
+    ) -> list[RoleBindingSummary]:
+        """List cluster role bindings.
+
+        Args:
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of role binding summaries (with is_cluster_binding=True).
+        """
+        self._log.debug("listing_cluster_role_bindings")
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.rbac_v1.list_cluster_role_binding(**kwargs)
+            items = [
+                RoleBindingSummary.from_k8s_object(rb, is_cluster_binding=True)
+                for rb in result.items
+            ]
+            self._log.debug("listed_cluster_role_bindings", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRoleBinding", None, None)
+
+    def get_cluster_role_binding(self, name: str) -> RoleBindingSummary:
+        """Get a single cluster role binding by name.
+
+        Args:
+            name: ClusterRoleBinding name.
+
+        Returns:
+            RoleBinding summary (with is_cluster_binding=True).
+        """
+        self._log.debug("getting_cluster_role_binding", name=name)
+        try:
+            result = self._client.rbac_v1.read_cluster_role_binding(name=name)
+            return RoleBindingSummary.from_k8s_object(result, is_cluster_binding=True)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRoleBinding", name, None)
+
+    def create_cluster_role_binding(
+        self,
+        name: str,
+        *,
+        role_ref: dict[str, str],
+        subjects: list[dict[str, str]],
+        labels: dict[str, str] | None = None,
+    ) -> RoleBindingSummary:
+        """Create a cluster role binding.
+
+        Args:
+            name: ClusterRoleBinding name.
+            role_ref: Role reference with 'kind' (ClusterRole), 'name', 'api_group'.
+            subjects: List of subjects.
+            labels: ClusterRoleBinding labels.
+
+        Returns:
+            Created cluster role binding summary.
+        """
+        from kubernetes.client import (
+            V1ClusterRoleBinding,
+            V1ObjectMeta,
+            V1RoleRef,
+            V1Subject,
+        )
+
+        body = V1ClusterRoleBinding(
+            metadata=V1ObjectMeta(name=name, labels=labels),
+            role_ref=V1RoleRef(
+                kind=role_ref.get("kind", "ClusterRole"),
+                name=role_ref["name"],
+                api_group=role_ref.get("api_group", "rbac.authorization.k8s.io"),
+            ),
+            subjects=[
+                V1Subject(
+                    kind=s.get("kind", "ServiceAccount"),
+                    name=s["name"],
+                    namespace=s.get("namespace"),
+                    api_group=s.get("api_group"),
+                )
+                for s in subjects
+            ],
+        )
+
+        self._log.info("creating_cluster_role_binding", name=name)
+        try:
+            result = self._client.rbac_v1.create_cluster_role_binding(body=body)
+            self._log.info("created_cluster_role_binding", name=name)
+            return RoleBindingSummary.from_k8s_object(result, is_cluster_binding=True)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRoleBinding", name, None)
+
+    def delete_cluster_role_binding(self, name: str) -> None:
+        """Delete a cluster role binding.
+
+        Args:
+            name: ClusterRoleBinding name.
+        """
+        self._log.info("deleting_cluster_role_binding", name=name)
+        try:
+            self._client.rbac_v1.delete_cluster_role_binding(name=name)
+            self._log.info("deleted_cluster_role_binding", name=name)
+        except Exception as e:
+            self._handle_api_error(e, "ClusterRoleBinding", name, None)

--- a/src/system_operations_manager/services/kubernetes/storage_manager.py
+++ b/src/system_operations_manager/services/kubernetes/storage_manager.py
@@ -1,0 +1,254 @@
+"""Kubernetes storage resource manager.
+
+Manages PersistentVolumes, PersistentVolumeClaims, and StorageClasses
+through the Kubernetes API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.storage import (
+    PersistentVolumeClaimSummary,
+    PersistentVolumeSummary,
+    StorageClassSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class StorageManager(K8sBaseManager):
+    """Manager for Kubernetes storage resources.
+
+    Provides operations for PersistentVolumes (cluster-scoped),
+    PersistentVolumeClaims (namespaced), and StorageClasses (cluster-scoped).
+    """
+
+    _entity_name = "storage"
+
+    # =========================================================================
+    # PersistentVolume Operations (Cluster-Scoped)
+    # =========================================================================
+
+    def list_persistent_volumes(
+        self,
+        *,
+        label_selector: str | None = None,
+    ) -> list[PersistentVolumeSummary]:
+        """List persistent volumes.
+
+        Args:
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of persistent volume summaries.
+        """
+        self._log.debug("listing_persistent_volumes")
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            result = self._client.core_v1.list_persistent_volume(**kwargs)
+            items = [PersistentVolumeSummary.from_k8s_object(pv) for pv in result.items]
+            self._log.debug("listed_persistent_volumes", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolume", None, None)
+
+    def get_persistent_volume(self, name: str) -> PersistentVolumeSummary:
+        """Get a single persistent volume by name.
+
+        Args:
+            name: PersistentVolume name.
+
+        Returns:
+            PersistentVolume summary.
+        """
+        self._log.debug("getting_persistent_volume", name=name)
+        try:
+            result = self._client.core_v1.read_persistent_volume(name=name)
+            return PersistentVolumeSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolume", name, None)
+
+    def delete_persistent_volume(self, name: str) -> None:
+        """Delete a persistent volume.
+
+        Args:
+            name: PersistentVolume name.
+        """
+        self._log.info("deleting_persistent_volume", name=name)
+        try:
+            self._client.core_v1.delete_persistent_volume(name=name)
+            self._log.info("deleted_persistent_volume", name=name)
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolume", name, None)
+
+    # =========================================================================
+    # PersistentVolumeClaim Operations (Namespaced)
+    # =========================================================================
+
+    def list_persistent_volume_claims(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[PersistentVolumeClaimSummary]:
+        """List persistent volume claims.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of PVC summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_pvcs", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_persistent_volume_claim_for_all_namespaces(
+                    **kwargs
+                )
+            else:
+                result = self._client.core_v1.list_namespaced_persistent_volume_claim(
+                    namespace=ns, **kwargs
+                )
+
+            items = [PersistentVolumeClaimSummary.from_k8s_object(pvc) for pvc in result.items]
+            self._log.debug("listed_pvcs", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolumeClaim", None, ns)
+
+    def get_persistent_volume_claim(
+        self, name: str, namespace: str | None = None
+    ) -> PersistentVolumeClaimSummary:
+        """Get a single PVC by name.
+
+        Args:
+            name: PVC name.
+            namespace: Target namespace.
+
+        Returns:
+            PVC summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_pvc", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_persistent_volume_claim(
+                name=name, namespace=ns
+            )
+            return PersistentVolumeClaimSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolumeClaim", name, ns)
+
+    def create_persistent_volume_claim(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        storage_class: str | None = None,
+        access_modes: list[str] | None = None,
+        storage: str = "1Gi",
+        labels: dict[str, str] | None = None,
+    ) -> PersistentVolumeClaimSummary:
+        """Create a persistent volume claim.
+
+        Args:
+            name: PVC name.
+            namespace: Target namespace.
+            storage_class: StorageClass name.
+            access_modes: Access modes (e.g., ['ReadWriteOnce']).
+            storage: Storage size (e.g., '10Gi').
+            labels: PVC labels.
+
+        Returns:
+            Created PVC summary.
+        """
+        from kubernetes.client import (
+            V1ObjectMeta,
+            V1PersistentVolumeClaim,
+            V1PersistentVolumeClaimSpec,
+            V1ResourceRequirements,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        modes = access_modes or ["ReadWriteOnce"]
+
+        body = V1PersistentVolumeClaim(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=labels),
+            spec=V1PersistentVolumeClaimSpec(
+                storage_class_name=storage_class,
+                access_modes=modes,
+                resources=V1ResourceRequirements(
+                    requests={"storage": storage},
+                ),
+            ),
+        )
+
+        self._log.info("creating_pvc", name=name, namespace=ns, storage=storage)
+        try:
+            result = self._client.core_v1.create_namespaced_persistent_volume_claim(
+                namespace=ns, body=body
+            )
+            self._log.info("created_pvc", name=name, namespace=ns)
+            return PersistentVolumeClaimSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolumeClaim", name, ns)
+
+    def delete_persistent_volume_claim(self, name: str, namespace: str | None = None) -> None:
+        """Delete a persistent volume claim.
+
+        Args:
+            name: PVC name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_pvc", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_persistent_volume_claim(name=name, namespace=ns)
+            self._log.info("deleted_pvc", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "PersistentVolumeClaim", name, ns)
+
+    # =========================================================================
+    # StorageClass Operations (Cluster-Scoped)
+    # =========================================================================
+
+    def list_storage_classes(self) -> list[StorageClassSummary]:
+        """List storage classes.
+
+        Returns:
+            List of storage class summaries.
+        """
+        self._log.debug("listing_storage_classes")
+        try:
+            result = self._client.storage_v1.list_storage_class()
+            items = [StorageClassSummary.from_k8s_object(sc) for sc in result.items]
+            self._log.debug("listed_storage_classes", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "StorageClass", None, None)
+
+    def get_storage_class(self, name: str) -> StorageClassSummary:
+        """Get a single storage class by name.
+
+        Args:
+            name: StorageClass name.
+
+        Returns:
+            StorageClass summary.
+        """
+        self._log.debug("getting_storage_class", name=name)
+        try:
+            result = self._client.storage_v1.read_storage_class(name=name)
+            return StorageClassSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StorageClass", name, None)

--- a/src/system_operations_manager/services/kubernetes/workload_manager.py
+++ b/src/system_operations_manager/services/kubernetes/workload_manager.py
@@ -1,0 +1,994 @@
+"""Kubernetes workload resource manager.
+
+Manages Pods, Deployments, StatefulSets, DaemonSets, and ReplicaSets
+through the Kubernetes API, providing CRUD operations plus workload-specific
+actions like scale, restart, rollout status, and rollback.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from system_operations_manager.integrations.kubernetes.models.workloads import (
+    DaemonSetSummary,
+    DeploymentSummary,
+    PodSummary,
+    ReplicaSetSummary,
+    StatefulSetSummary,
+)
+from system_operations_manager.services.kubernetes.base import K8sBaseManager
+
+
+class WorkloadManager(K8sBaseManager):
+    """Manager for Kubernetes workload resources.
+
+    Provides operations for Pods, Deployments, StatefulSets, DaemonSets,
+    and ReplicaSets including scale, restart, and rollback capabilities.
+    """
+
+    _entity_name = "workload"
+
+    # =========================================================================
+    # Pod Operations
+    # =========================================================================
+
+    def list_pods(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+        field_selector: str | None = None,
+    ) -> list[PodSummary]:
+        """List pods in a namespace or across all namespaces.
+
+        Args:
+            namespace: Target namespace (uses default if None).
+            all_namespaces: List pods across all namespaces.
+            label_selector: Filter by label selector (e.g., 'app=nginx').
+            field_selector: Filter by field selector (e.g., 'status.phase=Running').
+
+        Returns:
+            List of pod summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_pods", namespace=ns, all_namespaces=all_namespaces)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+            if field_selector:
+                kwargs["field_selector"] = field_selector
+
+            if all_namespaces:
+                result = self._client.core_v1.list_pod_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.core_v1.list_namespaced_pod(namespace=ns, **kwargs)
+
+            pods = [PodSummary.from_k8s_object(pod) for pod in result.items]
+            self._log.debug("listed_pods", count=len(pods))
+            return pods
+        except Exception as e:
+            self._handle_api_error(e, "Pod", None, ns)
+
+    def get_pod(self, name: str, namespace: str | None = None) -> PodSummary:
+        """Get a single pod by name.
+
+        Args:
+            name: Pod name.
+            namespace: Target namespace.
+
+        Returns:
+            Pod summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_pod", name=name, namespace=ns)
+        try:
+            result = self._client.core_v1.read_namespaced_pod(name=name, namespace=ns)
+            return PodSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Pod", name, ns)
+
+    def delete_pod(self, name: str, namespace: str | None = None) -> None:
+        """Delete a pod.
+
+        Args:
+            name: Pod name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_pod", name=name, namespace=ns)
+        try:
+            self._client.core_v1.delete_namespaced_pod(name=name, namespace=ns)
+            self._log.info("deleted_pod", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Pod", name, ns)
+
+    def get_pod_logs(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        container: str | None = None,
+        tail_lines: int | None = None,
+        previous: bool = False,
+    ) -> str:
+        """Get logs from a pod.
+
+        Args:
+            name: Pod name.
+            namespace: Target namespace.
+            container: Specific container name (required for multi-container pods).
+            tail_lines: Number of lines from the end of the log.
+            previous: Return logs from previous terminated container.
+
+        Returns:
+            Log content as string.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_pod_logs", name=name, namespace=ns, container=container)
+        try:
+            kwargs: dict[str, Any] = {"name": name, "namespace": ns}
+            if container:
+                kwargs["container"] = container
+            if tail_lines is not None:
+                kwargs["tail_lines"] = tail_lines
+            if previous:
+                kwargs["previous"] = previous
+
+            logs: str = self._client.core_v1.read_namespaced_pod_log(**kwargs)
+            return logs
+        except Exception as e:
+            self._handle_api_error(e, "Pod", name, ns)
+
+    # =========================================================================
+    # Deployment Operations
+    # =========================================================================
+
+    def list_deployments(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[DeploymentSummary]:
+        """List deployments.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of deployment summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_deployments", namespace=ns, all_namespaces=all_namespaces)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.apps_v1.list_deployment_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.apps_v1.list_namespaced_deployment(namespace=ns, **kwargs)
+
+            deployments = [DeploymentSummary.from_k8s_object(d) for d in result.items]
+            self._log.debug("listed_deployments", count=len(deployments))
+            return deployments
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", None, ns)
+
+    def get_deployment(self, name: str, namespace: str | None = None) -> DeploymentSummary:
+        """Get a single deployment by name.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+
+        Returns:
+            Deployment summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_deployment", name=name, namespace=ns)
+        try:
+            result = self._client.apps_v1.read_namespaced_deployment(name=name, namespace=ns)
+            return DeploymentSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def create_deployment(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str,
+        replicas: int = 1,
+        labels: dict[str, str] | None = None,
+        port: int | None = None,
+    ) -> DeploymentSummary:
+        """Create a deployment.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+            image: Container image.
+            replicas: Number of replicas.
+            labels: Labels for the deployment and pod template.
+            port: Container port to expose.
+
+        Returns:
+            Created deployment summary.
+        """
+        from kubernetes.client import (
+            V1Container,
+            V1ContainerPort,
+            V1Deployment,
+            V1DeploymentSpec,
+            V1LabelSelector,
+            V1ObjectMeta,
+            V1PodSpec,
+            V1PodTemplateSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        pod_labels = labels or {"app": name}
+
+        container = V1Container(
+            name=name,
+            image=image,
+            ports=[V1ContainerPort(container_port=port)] if port else None,
+        )
+
+        body = V1Deployment(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=pod_labels),
+            spec=V1DeploymentSpec(
+                replicas=replicas,
+                selector=V1LabelSelector(match_labels=pod_labels),
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(labels=pod_labels),
+                    spec=V1PodSpec(containers=[container]),
+                ),
+            ),
+        )
+
+        self._log.info(
+            "creating_deployment", name=name, namespace=ns, image=image, replicas=replicas
+        )
+        try:
+            result = self._client.apps_v1.create_namespaced_deployment(namespace=ns, body=body)
+            self._log.info("created_deployment", name=name, namespace=ns)
+            return DeploymentSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def update_deployment(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str | None = None,
+        replicas: int | None = None,
+    ) -> DeploymentSummary:
+        """Update a deployment (patch).
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+            image: New container image.
+            replicas: New replica count.
+
+        Returns:
+            Updated deployment summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_deployment", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if replicas is not None:
+                patch["spec"]["replicas"] = replicas
+            if image is not None:
+                patch["spec"]["template"] = {
+                    "spec": {"containers": [{"name": name, "image": image}]}
+                }
+
+            result = self._client.apps_v1.patch_namespaced_deployment(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_deployment", name=name, namespace=ns)
+            return DeploymentSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def delete_deployment(self, name: str, namespace: str | None = None) -> None:
+        """Delete a deployment.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_deployment", name=name, namespace=ns)
+        try:
+            self._client.apps_v1.delete_namespaced_deployment(name=name, namespace=ns)
+            self._log.info("deleted_deployment", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def scale_deployment(
+        self, name: str, namespace: str | None = None, *, replicas: int
+    ) -> DeploymentSummary:
+        """Scale a deployment to the specified number of replicas.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+            replicas: Desired replica count.
+
+        Returns:
+            Updated deployment summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("scaling_deployment", name=name, namespace=ns, replicas=replicas)
+        try:
+            patch = {"spec": {"replicas": replicas}}
+            result = self._client.apps_v1.patch_namespaced_deployment(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("scaled_deployment", name=name, namespace=ns, replicas=replicas)
+            return DeploymentSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def restart_deployment(self, name: str, namespace: str | None = None) -> DeploymentSummary:
+        """Restart a deployment by patching the pod template annotation.
+
+        Equivalent to ``kubectl rollout restart deployment``.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+
+        Returns:
+            Updated deployment summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("restarting_deployment", name=name, namespace=ns)
+        try:
+            now = datetime.now(UTC).isoformat()
+            patch = {
+                "spec": {
+                    "template": {
+                        "metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}
+                    }
+                }
+            }
+            result = self._client.apps_v1.patch_namespaced_deployment(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("restarted_deployment", name=name, namespace=ns)
+            return DeploymentSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def get_rollout_status(self, name: str, namespace: str | None = None) -> dict[str, Any]:
+        """Get the rollout status of a deployment.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+
+        Returns:
+            Dictionary with rollout status information.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_rollout_status", name=name, namespace=ns)
+        try:
+            result = self._client.apps_v1.read_namespaced_deployment(name=name, namespace=ns)
+            spec_replicas = getattr(result.spec, "replicas", 0) or 0
+            status = result.status
+            updated = getattr(status, "updated_replicas", 0) or 0
+            ready = getattr(status, "ready_replicas", 0) or 0
+            available = getattr(status, "available_replicas", 0) or 0
+
+            conditions = getattr(status, "conditions", None) or []
+            condition_messages = []
+            for cond in conditions:
+                condition_messages.append(
+                    {
+                        "type": getattr(cond, "type", ""),
+                        "status": getattr(cond, "status", ""),
+                        "reason": getattr(cond, "reason", ""),
+                        "message": getattr(cond, "message", ""),
+                    }
+                )
+
+            complete = updated == spec_replicas and ready == spec_replicas
+
+            return {
+                "name": name,
+                "namespace": ns,
+                "desired_replicas": spec_replicas,
+                "updated_replicas": updated,
+                "ready_replicas": ready,
+                "available_replicas": available,
+                "complete": complete,
+                "conditions": condition_messages,
+            }
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    def rollback_deployment(
+        self, name: str, namespace: str | None = None, *, revision: int | None = None
+    ) -> None:
+        """Rollback a deployment to a previous revision.
+
+        If no revision is specified, rolls back to the previous revision by
+        extracting the previous ReplicaSet's pod template and patching the
+        deployment.
+
+        Args:
+            name: Deployment name.
+            namespace: Target namespace.
+            revision: Target revision number (None for previous).
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("rolling_back_deployment", name=name, namespace=ns, revision=revision)
+        try:
+            # Get the deployment to find its selector
+            deployment = self._client.apps_v1.read_namespaced_deployment(name=name, namespace=ns)
+            selector = deployment.spec.selector.match_labels or {}
+            label_selector = ",".join(f"{k}={v}" for k, v in selector.items())
+
+            # Get ReplicaSets owned by this deployment
+            rs_list = self._client.apps_v1.list_namespaced_replica_set(
+                namespace=ns, label_selector=label_selector
+            )
+
+            # Filter to ReplicaSets owned by this deployment
+            owned_rs = []
+            for rs in rs_list.items:
+                owners = getattr(rs.metadata, "owner_references", None) or []
+                for owner in owners:
+                    if (
+                        getattr(owner, "kind", "") == "Deployment"
+                        and getattr(owner, "name", "") == name
+                    ):
+                        owned_rs.append(rs)
+                        break
+
+            if len(owned_rs) < 2:
+                self._log.warning("no_previous_revision", name=name, namespace=ns)
+                return
+
+            # Sort by revision annotation
+            def _get_revision(rs: Any) -> int:
+                annotations = getattr(rs.metadata, "annotations", None) or {}
+                rev_str = annotations.get("deployment.kubernetes.io/revision", "0")
+                try:
+                    return int(rev_str)
+                except (ValueError, TypeError):
+                    return 0
+
+            owned_rs.sort(key=_get_revision, reverse=True)
+
+            if revision is not None:
+                target_rs = next((rs for rs in owned_rs if _get_revision(rs) == revision), None)
+            else:
+                # Previous revision is the second newest
+                target_rs = owned_rs[1] if len(owned_rs) > 1 else None
+
+            if target_rs is None:
+                self._log.warning("revision_not_found", name=name, revision=revision)
+                return
+
+            # Patch deployment with the target RS's pod template
+            patch = {"spec": {"template": target_rs.spec.template}}
+            self._client.apps_v1.patch_namespaced_deployment(name=name, namespace=ns, body=patch)
+            self._log.info(
+                "rolled_back_deployment",
+                name=name,
+                namespace=ns,
+                to_revision=_get_revision(target_rs),
+            )
+        except Exception as e:
+            self._handle_api_error(e, "Deployment", name, ns)
+
+    # =========================================================================
+    # StatefulSet Operations
+    # =========================================================================
+
+    def list_stateful_sets(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[StatefulSetSummary]:
+        """List statefulsets.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of statefulset summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_statefulsets", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.apps_v1.list_stateful_set_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.apps_v1.list_namespaced_stateful_set(namespace=ns, **kwargs)
+
+            items = [StatefulSetSummary.from_k8s_object(s) for s in result.items]
+            self._log.debug("listed_statefulsets", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", None, ns)
+
+    def get_stateful_set(self, name: str, namespace: str | None = None) -> StatefulSetSummary:
+        """Get a single statefulset by name.
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+
+        Returns:
+            StatefulSet summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_statefulset", name=name, namespace=ns)
+        try:
+            result = self._client.apps_v1.read_namespaced_stateful_set(name=name, namespace=ns)
+            return StatefulSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    def create_stateful_set(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str,
+        replicas: int = 1,
+        service_name: str,
+        labels: dict[str, str] | None = None,
+        port: int | None = None,
+    ) -> StatefulSetSummary:
+        """Create a statefulset.
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+            image: Container image.
+            replicas: Number of replicas.
+            service_name: Headless service name.
+            labels: Labels for the statefulset and pod template.
+            port: Container port to expose.
+
+        Returns:
+            Created statefulset summary.
+        """
+        from kubernetes.client import (
+            V1Container,
+            V1ContainerPort,
+            V1LabelSelector,
+            V1ObjectMeta,
+            V1PodSpec,
+            V1PodTemplateSpec,
+            V1StatefulSet,
+            V1StatefulSetSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        pod_labels = labels or {"app": name}
+
+        container = V1Container(
+            name=name,
+            image=image,
+            ports=[V1ContainerPort(container_port=port)] if port else None,
+        )
+
+        body = V1StatefulSet(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=pod_labels),
+            spec=V1StatefulSetSpec(
+                replicas=replicas,
+                service_name=service_name,
+                selector=V1LabelSelector(match_labels=pod_labels),
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(labels=pod_labels),
+                    spec=V1PodSpec(containers=[container]),
+                ),
+            ),
+        )
+
+        self._log.info("creating_statefulset", name=name, namespace=ns, image=image)
+        try:
+            result = self._client.apps_v1.create_namespaced_stateful_set(namespace=ns, body=body)
+            self._log.info("created_statefulset", name=name, namespace=ns)
+            return StatefulSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    def update_stateful_set(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str | None = None,
+        replicas: int | None = None,
+    ) -> StatefulSetSummary:
+        """Update a statefulset (patch).
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+            image: New container image.
+            replicas: New replica count.
+
+        Returns:
+            Updated statefulset summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_statefulset", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if replicas is not None:
+                patch["spec"]["replicas"] = replicas
+            if image is not None:
+                patch["spec"]["template"] = {
+                    "spec": {"containers": [{"name": name, "image": image}]}
+                }
+
+            result = self._client.apps_v1.patch_namespaced_stateful_set(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_statefulset", name=name, namespace=ns)
+            return StatefulSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    def delete_stateful_set(self, name: str, namespace: str | None = None) -> None:
+        """Delete a statefulset.
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_statefulset", name=name, namespace=ns)
+        try:
+            self._client.apps_v1.delete_namespaced_stateful_set(name=name, namespace=ns)
+            self._log.info("deleted_statefulset", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    def scale_stateful_set(
+        self, name: str, namespace: str | None = None, *, replicas: int
+    ) -> StatefulSetSummary:
+        """Scale a statefulset.
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+            replicas: Desired replica count.
+
+        Returns:
+            Updated statefulset summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("scaling_statefulset", name=name, namespace=ns, replicas=replicas)
+        try:
+            patch = {"spec": {"replicas": replicas}}
+            result = self._client.apps_v1.patch_namespaced_stateful_set(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("scaled_statefulset", name=name, namespace=ns, replicas=replicas)
+            return StatefulSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    def restart_stateful_set(self, name: str, namespace: str | None = None) -> StatefulSetSummary:
+        """Restart a statefulset by patching the pod template annotation.
+
+        Args:
+            name: StatefulSet name.
+            namespace: Target namespace.
+
+        Returns:
+            Updated statefulset summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("restarting_statefulset", name=name, namespace=ns)
+        try:
+            now = datetime.now(UTC).isoformat()
+            patch = {
+                "spec": {
+                    "template": {
+                        "metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}
+                    }
+                }
+            }
+            result = self._client.apps_v1.patch_namespaced_stateful_set(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("restarted_statefulset", name=name, namespace=ns)
+            return StatefulSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "StatefulSet", name, ns)
+
+    # =========================================================================
+    # DaemonSet Operations
+    # =========================================================================
+
+    def list_daemon_sets(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[DaemonSetSummary]:
+        """List daemonsets.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of daemonset summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_daemonsets", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.apps_v1.list_daemon_set_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.apps_v1.list_namespaced_daemon_set(namespace=ns, **kwargs)
+
+            items = [DaemonSetSummary.from_k8s_object(d) for d in result.items]
+            self._log.debug("listed_daemonsets", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", None, ns)
+
+    def get_daemon_set(self, name: str, namespace: str | None = None) -> DaemonSetSummary:
+        """Get a single daemonset by name.
+
+        Args:
+            name: DaemonSet name.
+            namespace: Target namespace.
+
+        Returns:
+            DaemonSet summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_daemonset", name=name, namespace=ns)
+        try:
+            result = self._client.apps_v1.read_namespaced_daemon_set(name=name, namespace=ns)
+            return DaemonSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", name, ns)
+
+    def create_daemon_set(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str,
+        labels: dict[str, str] | None = None,
+        port: int | None = None,
+    ) -> DaemonSetSummary:
+        """Create a daemonset.
+
+        Args:
+            name: DaemonSet name.
+            namespace: Target namespace.
+            image: Container image.
+            labels: Labels for the daemonset and pod template.
+            port: Container port to expose.
+
+        Returns:
+            Created daemonset summary.
+        """
+        from kubernetes.client import (
+            V1Container,
+            V1ContainerPort,
+            V1DaemonSet,
+            V1DaemonSetSpec,
+            V1LabelSelector,
+            V1ObjectMeta,
+            V1PodSpec,
+            V1PodTemplateSpec,
+        )
+
+        ns = self._resolve_namespace(namespace)
+        pod_labels = labels or {"app": name}
+
+        container = V1Container(
+            name=name,
+            image=image,
+            ports=[V1ContainerPort(container_port=port)] if port else None,
+        )
+
+        body = V1DaemonSet(
+            metadata=V1ObjectMeta(name=name, namespace=ns, labels=pod_labels),
+            spec=V1DaemonSetSpec(
+                selector=V1LabelSelector(match_labels=pod_labels),
+                template=V1PodTemplateSpec(
+                    metadata=V1ObjectMeta(labels=pod_labels),
+                    spec=V1PodSpec(containers=[container]),
+                ),
+            ),
+        )
+
+        self._log.info("creating_daemonset", name=name, namespace=ns, image=image)
+        try:
+            result = self._client.apps_v1.create_namespaced_daemon_set(namespace=ns, body=body)
+            self._log.info("created_daemonset", name=name, namespace=ns)
+            return DaemonSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", name, ns)
+
+    def update_daemon_set(
+        self,
+        name: str,
+        namespace: str | None = None,
+        *,
+        image: str | None = None,
+    ) -> DaemonSetSummary:
+        """Update a daemonset (patch).
+
+        Args:
+            name: DaemonSet name.
+            namespace: Target namespace.
+            image: New container image.
+
+        Returns:
+            Updated daemonset summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("updating_daemonset", name=name, namespace=ns)
+        try:
+            patch: dict[str, Any] = {"spec": {}}
+            if image is not None:
+                patch["spec"]["template"] = {
+                    "spec": {"containers": [{"name": name, "image": image}]}
+                }
+
+            result = self._client.apps_v1.patch_namespaced_daemon_set(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("updated_daemonset", name=name, namespace=ns)
+            return DaemonSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", name, ns)
+
+    def delete_daemon_set(self, name: str, namespace: str | None = None) -> None:
+        """Delete a daemonset.
+
+        Args:
+            name: DaemonSet name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_daemonset", name=name, namespace=ns)
+        try:
+            self._client.apps_v1.delete_namespaced_daemon_set(name=name, namespace=ns)
+            self._log.info("deleted_daemonset", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", name, ns)
+
+    def restart_daemon_set(self, name: str, namespace: str | None = None) -> DaemonSetSummary:
+        """Restart a daemonset by patching the pod template annotation.
+
+        Args:
+            name: DaemonSet name.
+            namespace: Target namespace.
+
+        Returns:
+            Updated daemonset summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("restarting_daemonset", name=name, namespace=ns)
+        try:
+            now = datetime.now(UTC).isoformat()
+            patch = {
+                "spec": {
+                    "template": {
+                        "metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}
+                    }
+                }
+            }
+            result = self._client.apps_v1.patch_namespaced_daemon_set(
+                name=name, namespace=ns, body=patch
+            )
+            self._log.info("restarted_daemonset", name=name, namespace=ns)
+            return DaemonSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "DaemonSet", name, ns)
+
+    # =========================================================================
+    # ReplicaSet Operations
+    # =========================================================================
+
+    def list_replica_sets(
+        self,
+        namespace: str | None = None,
+        *,
+        all_namespaces: bool = False,
+        label_selector: str | None = None,
+    ) -> list[ReplicaSetSummary]:
+        """List replicasets.
+
+        Args:
+            namespace: Target namespace.
+            all_namespaces: List across all namespaces.
+            label_selector: Filter by label selector.
+
+        Returns:
+            List of replicaset summaries.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("listing_replicasets", namespace=ns)
+        try:
+            kwargs: dict[str, Any] = {}
+            if label_selector:
+                kwargs["label_selector"] = label_selector
+
+            if all_namespaces:
+                result = self._client.apps_v1.list_replica_set_for_all_namespaces(**kwargs)
+            else:
+                result = self._client.apps_v1.list_namespaced_replica_set(namespace=ns, **kwargs)
+
+            items = [ReplicaSetSummary.from_k8s_object(rs) for rs in result.items]
+            self._log.debug("listed_replicasets", count=len(items))
+            return items
+        except Exception as e:
+            self._handle_api_error(e, "ReplicaSet", None, ns)
+
+    def get_replica_set(self, name: str, namespace: str | None = None) -> ReplicaSetSummary:
+        """Get a single replicaset by name.
+
+        Args:
+            name: ReplicaSet name.
+            namespace: Target namespace.
+
+        Returns:
+            ReplicaSet summary.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.debug("getting_replicaset", name=name, namespace=ns)
+        try:
+            result = self._client.apps_v1.read_namespaced_replica_set(name=name, namespace=ns)
+            return ReplicaSetSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "ReplicaSet", name, ns)
+
+    def delete_replica_set(self, name: str, namespace: str | None = None) -> None:
+        """Delete a replicaset.
+
+        Args:
+            name: ReplicaSet name.
+            namespace: Target namespace.
+        """
+        ns = self._resolve_namespace(namespace)
+        self._log.info("deleting_replicaset", name=name, namespace=ns)
+        try:
+            self._client.apps_v1.delete_namespaced_replica_set(name=name, namespace=ns)
+            self._log.info("deleted_replicaset", name=name, namespace=ns)
+        except Exception as e:
+            self._handle_api_error(e, "ReplicaSet", name, ns)


### PR DESCRIPTION
## Summary

- Add 7 Kubernetes service managers providing business logic for all K8s resource types, building on the integration layer from #44
- Create `K8sBaseManager` base class with shared client reference, structured logging, namespace resolution, and API error translation
- Implement `WorkloadManager` (Pods, Deployments, StatefulSets, DaemonSets, ReplicaSets with scale/restart/rollback), `NetworkingManager` (Services, Ingresses, NetworkPolicies), `ConfigurationManager` (ConfigMaps, Secrets including TLS and docker-registry), `NamespaceClusterManager` (Namespaces, Nodes, Events, cluster info), `JobManager` (Jobs, CronJobs with suspend/resume), `StorageManager` (PVs, PVCs, StorageClasses), and `RBACManager` (ServiceAccounts, Roles, ClusterRoles, Bindings)

## Design decisions

- **Lightweight base vs generic CRUD**: Unlike Kong's `BaseEntityManager[T]` which wraps a uniform REST client, K8s SDK has unique method names per resource type (`list_namespaced_pod`, `create_namespaced_deployment`). A lightweight `K8sBaseManager` provides only shared concerns without forcing unnecessary abstraction.
- **Security**: Secret values are never exposed in display models — only key names are returned.
- **Error handling**: All managers consistently translate `ApiException` to typed custom exceptions via `_handle_api_error()`.

## Files changed (9 files, +3,511 lines)

| File | Description |
|------|-------------|
| `services/kubernetes/base.py` | `K8sBaseManager` — shared base for all managers |
| `services/kubernetes/workload_manager.py` | Pods, Deployments, StatefulSets, DaemonSets, ReplicaSets |
| `services/kubernetes/networking_manager.py` | Services, Ingresses, NetworkPolicies |
| `services/kubernetes/configuration_manager.py` | ConfigMaps, Secrets (Opaque, TLS, docker-registry) |
| `services/kubernetes/namespace_manager.py` | Namespaces, Nodes, Events, cluster info |
| `services/kubernetes/job_manager.py` | Jobs, CronJobs with suspend/resume |
| `services/kubernetes/storage_manager.py` | PVs, PVCs, StorageClasses |
| `services/kubernetes/rbac_manager.py` | ServiceAccounts, Roles, ClusterRoles, Bindings |
| `services/kubernetes/__init__.py` | Updated exports for all new managers |

## Test plan

- [x] `ruff check` passes with no errors
- [x] `ruff format` applied (all files formatted)
- [x] All managers import successfully
- [x] Full test suite: 2060 passed, 74 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)