### PR TITLE
system-operations-manager-uy8: TUI resource detail screen

### DIFF
--- a/src/system_operations_manager/tui/apps/kubernetes/app.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/app.py
@@ -15,6 +15,7 @@ from textual.widgets import Footer, Header
 
 from system_operations_manager.tui.apps.kubernetes.screens import (
     DashboardScreen,
+    ResourceDetailScreen,
     ResourceListScreen,
 )
 from system_operations_manager.tui.apps.kubernetes.types import (
@@ -32,6 +33,7 @@ __all__ = [
     "RESOURCE_TYPE_ORDER",
     "DashboardScreen",
     "KubernetesApp",
+    "ResourceDetailScreen",
     "ResourceType",
 ]
 
@@ -96,9 +98,11 @@ class KubernetesApp(App[None]):
 
     @on(ResourceListScreen.ResourceSelected)
     def handle_resource_selected(self, event: ResourceListScreen.ResourceSelected) -> None:
-        """Handle resource selection from list.
-
-        Currently shows a notification. The detail screen is
-        implemented in a separate task (system-operations-manager-uy8).
-        """
-        self.notify(f"Selected: {event.resource_type.value} / {event.resource.name}")
+        """Handle resource selection from list by pushing the detail screen."""
+        self.push_screen(
+            ResourceDetailScreen(
+                resource=event.resource,
+                resource_type=event.resource_type,
+                client=self._client,
+            )
+        )

--- a/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
+++ b/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
@@ -127,3 +127,87 @@ DataTable > .datatable--cursor {
     margin-bottom: 1;
     color: $text;
 }
+
+/* ============================================ */
+/* Resource Detail Screen Styles                */
+/* ============================================ */
+
+#detail-container {
+    padding: 1;
+}
+
+#detail-header {
+    height: 3;
+    dock: top;
+    padding: 0 1;
+    text-style: bold;
+}
+
+#detail-top-row {
+    height: auto;
+    max-height: 30%;
+    padding: 0;
+}
+
+#detail-mid-row {
+    height: auto;
+    max-height: 25%;
+    padding: 0;
+    margin-top: 1;
+}
+
+.detail-panel {
+    border: solid $primary;
+    padding: 1;
+    height: auto;
+}
+
+#metadata-panel {
+    width: 50%;
+    margin-right: 1;
+}
+
+#status-panel {
+    width: 50%;
+}
+
+#labels-panel {
+    width: 50%;
+    margin-right: 1;
+    max-height: 100%;
+    overflow-y: auto;
+}
+
+#annotations-panel {
+    width: 50%;
+    max-height: 100%;
+    overflow-y: auto;
+}
+
+#yaml-panel {
+    margin-top: 1;
+    border: solid $accent;
+    height: auto;
+    max-height: 35%;
+}
+
+#detail-yaml-scroll {
+    height: auto;
+    max-height: 100%;
+}
+
+#detail-yaml-content {
+    height: auto;
+}
+
+#detail-events-panel {
+    margin-top: 1;
+    border: solid $warning;
+    height: auto;
+    max-height: 25%;
+}
+
+#detail-events-panel #detail-events-table {
+    height: auto;
+    max-height: 100%;
+}


### PR DESCRIPTION
## Summary
- Add `ResourceDetailScreen` with metadata, status indicators, labels/annotations, YAML viewer, and related events panels
- Wire up resource selection in `KubernetesApp` to push the detail screen instead of showing a notification
- Add 23 unit tests covering all text builders, bindings, and edge cases

## Task
Closes beads task `system-operations-manager-uy8`: TUI resource detail screen

## Changes
- `src/.../tui/apps/kubernetes/screens.py` — Added `ResourceDetailScreen` class (~300 lines) with header, metadata, status (type-specific), labels, annotations, YAML, and events panels
- `src/.../tui/apps/kubernetes/app.py` — Updated `handle_resource_selected` to push detail screen, added to `__all__`
- `src/.../tui/apps/kubernetes/styles.tcss` — Added CSS for detail screen layout (panels, YAML scroll, events table)
- `tests/unit/tui/apps/kubernetes/test_screens.py` — Added 23 tests for `ResourceDetailScreen`

## Validation
- [x] All tests pass (3525 passed, 74 skipped)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] Type check clean (`mypy`)
- [x] Manual review of implementation checklist

Generated with [Claude Code](https://claude.com/claude-code)