### PR TITLE
system-operations-manager-t9c: TUI CRUD operations

### DIFF
--- a/src/system_operations_manager/services/kubernetes/namespace_manager.py
+++ b/src/system_operations_manager/services/kubernetes/namespace_manager.py
@@ -112,6 +112,37 @@ class NamespaceClusterManager(K8sBaseManager):
         except Exception as e:
             self._handle_api_error(e, "Namespace", name, None)
 
+    def update_namespace(
+        self,
+        name: str,
+        *,
+        labels: dict[str, str] | None = None,
+        annotations: dict[str, str] | None = None,
+    ) -> NamespaceSummary:
+        """Update a namespace's metadata (patch).
+
+        Args:
+            name: Namespace name.
+            labels: New labels for the namespace.
+            annotations: New annotations for the namespace.
+
+        Returns:
+            Updated namespace summary.
+        """
+        self._log.info("updating_namespace", name=name)
+        try:
+            patch: dict[str, Any] = {"metadata": {}}
+            if labels is not None:
+                patch["metadata"]["labels"] = labels
+            if annotations is not None:
+                patch["metadata"]["annotations"] = annotations
+
+            result = self._client.core_v1.patch_namespace(name=name, body=patch)
+            self._log.info("updated_namespace", name=name)
+            return NamespaceSummary.from_k8s_object(result)
+        except Exception as e:
+            self._handle_api_error(e, "Namespace", name, None)
+
     # =========================================================================
     # Node Operations
     # =========================================================================

--- a/src/system_operations_manager/tui/apps/kubernetes/app.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/app.py
@@ -93,7 +93,8 @@ class KubernetesApp(App[None]):
         """Show keyboard shortcut help."""
         self.notify(
             "j/k: navigate | Enter: select | n/N: namespace | "
-            "c/C: cluster | f/F: resource type | r: refresh | d: dashboard | q: quit"
+            "c/C: cluster | f/F: resource type | r: refresh | "
+            "a: create | d: delete | e: edit | q: quit"
         )
 
     @on(ResourceListScreen.ResourceSelected)

--- a/src/system_operations_manager/tui/apps/kubernetes/create_screen.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/create_screen.py
@@ -1,0 +1,609 @@
+"""Form-based resource creation screen for Kubernetes TUI.
+
+Provides a dynamic form that adapts its fields based on the selected
+resource type. Uses a field-spec registry to define what inputs each
+resource type requires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from textual.app import ComposeResult
+from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.message import Message
+from textual.widgets import Button, Input, Label, Select, TextArea
+
+from system_operations_manager.tui.apps.kubernetes.types import (
+    CLUSTER_SCOPED_TYPES,
+    ResourceType,
+)
+from system_operations_manager.tui.base import BaseScreen
+
+if TYPE_CHECKING:
+    from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Field specification
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldSpec:
+    """Describes a single form field for resource creation."""
+
+    name: str
+    label: str
+    field_type: str = "text"  # text | int | select | textarea
+    required: bool = False
+    default: str = ""
+    options: list[tuple[str, str]] | None = None  # (label, value) for selects
+    placeholder: str = ""
+    help_text: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Per-resource-type field definitions
+# ---------------------------------------------------------------------------
+
+RESOURCE_FIELD_SPECS: dict[ResourceType, list[FieldSpec]] = {
+    ResourceType.DEPLOYMENTS: [
+        FieldSpec("name", "Name", required=True, placeholder="my-deployment"),
+        FieldSpec("image", "Image", required=True, placeholder="nginx:latest"),
+        FieldSpec("replicas", "Replicas", field_type="int", default="1"),
+        FieldSpec("port", "Container Port", field_type="int", placeholder="80"),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+            help_text="Labels as key=value pairs, one per line",
+        ),
+    ],
+    ResourceType.STATEFULSETS: [
+        FieldSpec("name", "Name", required=True, placeholder="my-statefulset"),
+        FieldSpec("image", "Image", required=True, placeholder="postgres:16"),
+        FieldSpec("replicas", "Replicas", field_type="int", default="1"),
+        FieldSpec(
+            "service_name",
+            "Headless Service",
+            required=True,
+            placeholder="my-svc-headless",
+        ),
+        FieldSpec("port", "Container Port", field_type="int", placeholder="5432"),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.DAEMONSETS: [
+        FieldSpec("name", "Name", required=True, placeholder="my-daemonset"),
+        FieldSpec("image", "Image", required=True, placeholder="fluent-bit:latest"),
+        FieldSpec("port", "Container Port", field_type="int", placeholder="2020"),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.SERVICES: [
+        FieldSpec("name", "Name", required=True, placeholder="my-service"),
+        FieldSpec(
+            "type",
+            "Type",
+            field_type="select",
+            default="ClusterIP",
+            options=[
+                ("ClusterIP", "ClusterIP"),
+                ("NodePort", "NodePort"),
+                ("LoadBalancer", "LoadBalancer"),
+                ("ExternalName", "ExternalName"),
+            ],
+        ),
+        FieldSpec(
+            "selector",
+            "Selector",
+            field_type="textarea",
+            placeholder="app=my-app (one per line)",
+            help_text="Pod selector as key=value pairs",
+        ),
+        FieldSpec(
+            "ports",
+            "Ports",
+            field_type="textarea",
+            placeholder="port=80,target_port=8080 (one per line)",
+            help_text="Port mappings: port=N,target_port=N,protocol=TCP",
+        ),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.INGRESSES: [
+        FieldSpec("name", "Name", required=True, placeholder="my-ingress"),
+        FieldSpec("class_name", "Ingress Class", placeholder="nginx"),
+        FieldSpec(
+            "rules",
+            "Rules (YAML)",
+            field_type="textarea",
+            placeholder=(
+                "- host: example.com\n"
+                "  paths:\n"
+                "    - path: /\n"
+                "      path_type: Prefix\n"
+                "      service_name: my-svc\n"
+                "      service_port: 80"
+            ),
+            help_text="Ingress rules in YAML list format",
+        ),
+        FieldSpec(
+            "tls",
+            "TLS (YAML)",
+            field_type="textarea",
+            placeholder=(
+                "- hosts:\n"
+                "    - example.com\n"
+                "  secret_name: tls-secret"
+            ),
+            help_text="TLS config in YAML list format",
+        ),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.NETWORK_POLICIES: [
+        FieldSpec("name", "Name", required=True, placeholder="my-netpol"),
+        FieldSpec(
+            "pod_selector",
+            "Pod Selector",
+            field_type="textarea",
+            placeholder="app=my-app (one per line)",
+            help_text="Pod selector as key=value pairs",
+        ),
+        FieldSpec(
+            "policy_types",
+            "Policy Types",
+            placeholder="Ingress,Egress",
+            help_text="Comma-separated: Ingress, Egress",
+        ),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.CONFIGMAPS: [
+        FieldSpec("name", "Name", required=True, placeholder="my-configmap"),
+        FieldSpec(
+            "data",
+            "Data",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+            help_text="ConfigMap data as key=value pairs",
+        ),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.SECRETS: [
+        FieldSpec("name", "Name", required=True, placeholder="my-secret"),
+        FieldSpec(
+            "secret_type",
+            "Secret Type",
+            field_type="select",
+            default="Opaque",
+            options=[
+                ("Opaque", "Opaque"),
+                ("TLS", "kubernetes.io/tls"),
+                ("Docker Registry", "kubernetes.io/dockerconfigjson"),
+            ],
+        ),
+        FieldSpec(
+            "data",
+            "Data",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+            help_text="Secret data as key=value pairs (values will be base64-encoded)",
+        ),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+    ResourceType.NAMESPACES: [
+        FieldSpec("name", "Name", required=True, placeholder="my-namespace"),
+        FieldSpec(
+            "labels",
+            "Labels",
+            field_type="textarea",
+            placeholder="key=value (one per line)",
+        ),
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_key_value_lines(text: str) -> dict[str, str]:
+    """Parse ``key=value`` lines into a dict, skipping blank lines."""
+    result: dict[str, str] = {}
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _parse_port_lines(text: str) -> list[dict[str, Any]]:
+    """Parse port definitions from ``key=value`` comma-separated lines.
+
+    Each line describes one port mapping::
+
+        port=80,target_port=8080,protocol=TCP,name=http
+    """
+    ports: list[dict[str, Any]] = []
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = _parse_key_value_lines(line.replace(",", "\n"))
+        if "port" not in parts:
+            continue
+        port_def: dict[str, Any] = {"port": int(parts["port"])}
+        if "target_port" in parts:
+            try:
+                port_def["target_port"] = int(parts["target_port"])
+            except ValueError:
+                port_def["target_port"] = parts["target_port"]
+        if "protocol" in parts:
+            port_def["protocol"] = parts["protocol"]
+        if "name" in parts:
+            port_def["name"] = parts["name"]
+        ports.append(port_def)
+    return ports
+
+
+# ---------------------------------------------------------------------------
+# Create screen
+# ---------------------------------------------------------------------------
+
+
+class ResourceCreateScreen(BaseScreen[None]):
+    """Form-based screen for creating Kubernetes resources."""
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+        ("ctrl+s", "submit", "Create"),
+    ]
+
+    class ResourceCreated(Message):
+        """Emitted when a resource is successfully created."""
+
+        def __init__(self, resource_type: ResourceType, name: str) -> None:
+            self.resource_type = resource_type
+            self.resource_name = name
+            super().__init__()
+
+    def __init__(
+        self,
+        resource_type: ResourceType,
+        client: KubernetesClient,
+        namespace: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._resource_type = resource_type
+        self._client = client
+        self._namespace = namespace
+        self._field_specs = RESOURCE_FIELD_SPECS[resource_type]
+        self._log = logger.bind(screen="create", resource_type=resource_type.value)
+
+    def compose(self) -> ComposeResult:
+        """Build the form dynamically from the field spec registry."""
+        type_label = self._resource_type.value
+        if type_label.endswith("s"):
+            type_label = type_label[:-1]
+
+        yield Label(f"Create {type_label}", id="create-header")
+
+        with ScrollableContainer(id="create-form"):
+            # Namespace field for namespaced resources
+            if self._resource_type not in CLUSTER_SCOPED_TYPES:
+                with Vertical(classes="form-field"):
+                    yield Label("Namespace", classes="form-label")
+                    yield Input(
+                        value=self._namespace or "",
+                        placeholder="default",
+                        id="field-namespace",
+                    )
+
+            for spec in self._field_specs:
+                with Vertical(classes="form-field"):
+                    label_text = spec.label
+                    if spec.required:
+                        label_text += " *"
+                    yield Label(label_text, classes="form-label")
+
+                    if spec.field_type == "select" and spec.options:
+                        yield Select(
+                            [(label, value) for label, value in spec.options],
+                            value=spec.default or Select.BLANK,
+                            id=f"field-{spec.name}",
+                        )
+                    elif spec.field_type == "textarea":
+                        yield TextArea(
+                            spec.default,
+                            id=f"field-{spec.name}",
+                        )
+                    elif spec.field_type == "int":
+                        yield Input(
+                            value=spec.default,
+                            placeholder=spec.placeholder,
+                            id=f"field-{spec.name}",
+                            type="integer",
+                        )
+                    else:
+                        yield Input(
+                            value=spec.default,
+                            placeholder=spec.placeholder,
+                            id=f"field-{spec.name}",
+                        )
+
+                    if spec.help_text:
+                        yield Label(spec.help_text, classes="form-help")
+
+        with Horizontal(id="create-buttons"):
+            yield Button("Create", variant="success", id="btn-create")
+            yield Button("Cancel", variant="default", id="btn-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button clicks."""
+        if event.button.id == "btn-create":
+            self.action_submit()
+        elif event.button.id == "btn-cancel":
+            self.action_cancel()
+
+    def action_cancel(self) -> None:
+        """Go back without creating."""
+        self.go_back()
+
+    def action_submit(self) -> None:
+        """Validate fields and create the resource."""
+        values = self._collect_values()
+        if values is None:
+            return
+
+        try:
+            name = self._create_resource(values)
+            self.post_message(self.ResourceCreated(self._resource_type, name))
+            self.notify_user(f"Created {self._resource_type.value[:-1]} '{name}'")
+            self.go_back()
+        except Exception as e:
+            self.notify_user(f"Create failed: {e}", severity="error")
+
+    def _collect_values(self) -> dict[str, Any] | None:
+        """Collect and validate form field values.
+
+        Returns:
+            Dictionary of field values, or None if validation fails.
+        """
+        values: dict[str, Any] = {}
+
+        # Namespace
+        if self._resource_type not in CLUSTER_SCOPED_TYPES:
+            ns_input = self.query_one("#field-namespace", Input)
+            values["namespace"] = ns_input.value.strip() or self._namespace
+
+        for spec in self._field_specs:
+            widget_id = f"#field-{spec.name}"
+
+            if spec.field_type == "select":
+                widget = self.query_one(widget_id, Select)
+                raw = str(widget.value) if widget.value != Select.BLANK else spec.default
+            elif spec.field_type == "textarea":
+                widget = self.query_one(widget_id, TextArea)
+                raw = widget.text.strip()
+            else:
+                widget = self.query_one(widget_id, Input)
+                raw = widget.value.strip()
+
+            if spec.required and not raw:
+                self.notify_user(f"{spec.label} is required", severity="error")
+                return None
+
+            if spec.field_type == "int" and raw:
+                try:
+                    values[spec.name] = int(raw)
+                except ValueError:
+                    self.notify_user(
+                        f"{spec.label} must be a number", severity="error"
+                    )
+                    return None
+            else:
+                values[spec.name] = raw
+
+        return values
+
+    def _create_resource(self, values: dict[str, Any]) -> str:
+        """Dispatch to the correct service manager create method.
+
+        Returns:
+            The name of the created resource.
+        """
+        name = values["name"]
+        namespace = values.get("namespace")
+        labels = _parse_key_value_lines(values.get("labels", "")) or None
+
+        rt = self._resource_type
+
+        if rt == ResourceType.DEPLOYMENTS:
+            from system_operations_manager.services.kubernetes.workload_manager import (
+                WorkloadManager,
+            )
+
+            mgr = WorkloadManager(self._client)
+            kwargs: dict[str, Any] = {"image": values["image"]}
+            if values.get("replicas"):
+                kwargs["replicas"] = values["replicas"]
+            if values.get("port"):
+                kwargs["port"] = values["port"]
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_deployment(name, namespace, **kwargs)
+
+        elif rt == ResourceType.STATEFULSETS:
+            from system_operations_manager.services.kubernetes.workload_manager import (
+                WorkloadManager,
+            )
+
+            mgr = WorkloadManager(self._client)
+            kwargs = {
+                "image": values["image"],
+                "service_name": values["service_name"],
+            }
+            if values.get("replicas"):
+                kwargs["replicas"] = values["replicas"]
+            if values.get("port"):
+                kwargs["port"] = values["port"]
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_stateful_set(name, namespace, **kwargs)
+
+        elif rt == ResourceType.DAEMONSETS:
+            from system_operations_manager.services.kubernetes.workload_manager import (
+                WorkloadManager,
+            )
+
+            mgr = WorkloadManager(self._client)
+            kwargs = {"image": values["image"]}
+            if values.get("port"):
+                kwargs["port"] = values["port"]
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_daemon_set(name, namespace, **kwargs)
+
+        elif rt == ResourceType.SERVICES:
+            from system_operations_manager.services.kubernetes.networking_manager import (
+                NetworkingManager,
+            )
+
+            mgr = NetworkingManager(self._client)
+            kwargs = {}
+            if values.get("type"):
+                kwargs["type"] = values["type"]
+            selector = _parse_key_value_lines(values.get("selector", ""))
+            if selector:
+                kwargs["selector"] = selector
+            ports = _parse_port_lines(values.get("ports", ""))
+            if ports:
+                kwargs["ports"] = ports
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_service(name, namespace, **kwargs)
+
+        elif rt == ResourceType.INGRESSES:
+            from system_operations_manager.services.kubernetes.networking_manager import (
+                NetworkingManager,
+            )
+
+            mgr = NetworkingManager(self._client)
+            kwargs = {}
+            if values.get("class_name"):
+                kwargs["class_name"] = values["class_name"]
+            if values.get("rules"):
+                import yaml
+
+                rules = yaml.safe_load(values["rules"])
+                if isinstance(rules, list):
+                    kwargs["rules"] = rules
+            if values.get("tls"):
+                import yaml
+
+                tls = yaml.safe_load(values["tls"])
+                if isinstance(tls, list):
+                    kwargs["tls"] = tls
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_ingress(name, namespace, **kwargs)
+
+        elif rt == ResourceType.NETWORK_POLICIES:
+            from system_operations_manager.services.kubernetes.networking_manager import (
+                NetworkingManager,
+            )
+
+            mgr = NetworkingManager(self._client)
+            kwargs = {}
+            pod_selector = _parse_key_value_lines(
+                values.get("pod_selector", "")
+            )
+            if pod_selector:
+                kwargs["pod_selector"] = pod_selector
+            if values.get("policy_types"):
+                kwargs["policy_types"] = [
+                    t.strip()
+                    for t in values["policy_types"].split(",")
+                    if t.strip()
+                ]
+            if labels:
+                kwargs["labels"] = labels
+            mgr.create_network_policy(name, namespace, **kwargs)
+
+        elif rt == ResourceType.CONFIGMAPS:
+            from system_operations_manager.services.kubernetes.configuration_manager import (
+                ConfigurationManager,
+            )
+
+            mgr = ConfigurationManager(self._client)
+            data = _parse_key_value_lines(values.get("data", "")) or None
+            mgr.create_config_map(name, namespace, data=data, labels=labels)
+
+        elif rt == ResourceType.SECRETS:
+            from system_operations_manager.services.kubernetes.configuration_manager import (
+                ConfigurationManager,
+            )
+
+            mgr = ConfigurationManager(self._client)
+            data = _parse_key_value_lines(values.get("data", "")) or None
+            secret_type = values.get("secret_type", "Opaque")
+            mgr.create_secret(
+                name, namespace, data=data, secret_type=secret_type, labels=labels
+            )
+
+        elif rt == ResourceType.NAMESPACES:
+            from system_operations_manager.services.kubernetes.namespace_manager import (
+                NamespaceClusterManager,
+            )
+
+            mgr = NamespaceClusterManager(self._client)
+            mgr.create_namespace(name, labels=labels)
+
+        else:
+            msg = f"Create not supported for {rt.value}"
+            raise ValueError(msg)
+
+        return name

--- a/src/system_operations_manager/tui/apps/kubernetes/create_screen.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/create_screen.py
@@ -7,7 +7,7 @@ resource type requires.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -150,11 +150,7 @@ RESOURCE_FIELD_SPECS: dict[ResourceType, list[FieldSpec]] = {
             "tls",
             "TLS (YAML)",
             field_type="textarea",
-            placeholder=(
-                "- hosts:\n"
-                "    - example.com\n"
-                "  secret_name: tls-secret"
-            ),
+            placeholder=("- hosts:\n    - example.com\n  secret_name: tls-secret"),
             help_text="TLS config in YAML list format",
         ),
         FieldSpec(
@@ -440,9 +436,7 @@ class ResourceCreateScreen(BaseScreen[None]):
                 try:
                     values[spec.name] = int(raw)
                 except ValueError:
-                    self.notify_user(
-                        f"{spec.label} must be a number", severity="error"
-                    )
+                    self.notify_user(f"{spec.label} must be a number", severity="error")
                     return None
             else:
                 values[spec.name] = raw
@@ -558,16 +552,12 @@ class ResourceCreateScreen(BaseScreen[None]):
 
             mgr = NetworkingManager(self._client)
             kwargs = {}
-            pod_selector = _parse_key_value_lines(
-                values.get("pod_selector", "")
-            )
+            pod_selector = _parse_key_value_lines(values.get("pod_selector", ""))
             if pod_selector:
                 kwargs["pod_selector"] = pod_selector
             if values.get("policy_types"):
                 kwargs["policy_types"] = [
-                    t.strip()
-                    for t in values["policy_types"].split(",")
-                    if t.strip()
+                    t.strip() for t in values["policy_types"].split(",") if t.strip()
                 ]
             if labels:
                 kwargs["labels"] = labels
@@ -590,9 +580,7 @@ class ResourceCreateScreen(BaseScreen[None]):
             mgr = ConfigurationManager(self._client)
             data = _parse_key_value_lines(values.get("data", "")) or None
             secret_type = values.get("secret_type", "Opaque")
-            mgr.create_secret(
-                name, namespace, data=data, secret_type=secret_type, labels=labels
-            )
+            mgr.create_secret(name, namespace, data=data, secret_type=secret_type, labels=labels)
 
         elif rt == ResourceType.NAMESPACES:
             from system_operations_manager.services.kubernetes.namespace_manager import (

--- a/src/system_operations_manager/tui/apps/kubernetes/delete_helpers.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/delete_helpers.py
@@ -1,0 +1,61 @@
+"""Helpers for deleting Kubernetes resources via TUI.
+
+Maps resource types to their corresponding Kubernetes API delete methods
+for uniform dispatch from any TUI screen.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from system_operations_manager.tui.apps.kubernetes.types import ResourceType
+
+if TYPE_CHECKING:
+    from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+
+# Maps ResourceType -> (api_property, delete_method_name, is_namespaced)
+RESOURCE_DELETE_MAP: dict[ResourceType, tuple[str, str, bool]] = {
+    ResourceType.PODS: ("core_v1", "delete_namespaced_pod", True),
+    ResourceType.DEPLOYMENTS: ("apps_v1", "delete_namespaced_deployment", True),
+    ResourceType.STATEFULSETS: ("apps_v1", "delete_namespaced_stateful_set", True),
+    ResourceType.DAEMONSETS: ("apps_v1", "delete_namespaced_daemon_set", True),
+    ResourceType.REPLICASETS: ("apps_v1", "delete_namespaced_replica_set", True),
+    ResourceType.SERVICES: ("core_v1", "delete_namespaced_service", True),
+    ResourceType.INGRESSES: ("networking_v1", "delete_namespaced_ingress", True),
+    ResourceType.NETWORK_POLICIES: (
+        "networking_v1",
+        "delete_namespaced_network_policy",
+        True,
+    ),
+    ResourceType.CONFIGMAPS: ("core_v1", "delete_namespaced_config_map", True),
+    ResourceType.SECRETS: ("core_v1", "delete_namespaced_secret", True),
+    ResourceType.NAMESPACES: ("core_v1", "delete_namespace", False),
+}
+
+
+def delete_resource(
+    client: KubernetesClient,
+    resource_type: ResourceType,
+    name: str,
+    namespace: str | None,
+) -> None:
+    """Delete a Kubernetes resource.
+
+    Args:
+        client: Kubernetes API client.
+        resource_type: Type of resource to delete.
+        name: Resource name.
+        namespace: Resource namespace (ignored for cluster-scoped types).
+
+    Raises:
+        KeyError: If the resource type does not support deletion.
+        KubernetesError: If the API call fails.
+    """
+    api_attr, delete_method, is_namespaced = RESOURCE_DELETE_MAP[resource_type]
+    api = getattr(client, api_attr)
+    delete_fn = getattr(api, delete_method)
+
+    if is_namespaced:
+        delete_fn(name=name, namespace=namespace or client.default_namespace)
+    else:
+        delete_fn(name=name)

--- a/src/system_operations_manager/tui/apps/kubernetes/edit_helpers.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/edit_helpers.py
@@ -1,0 +1,177 @@
+"""Helpers for YAML-based editing of Kubernetes resources via TUI.
+
+Provides functions to fetch raw Kubernetes objects as clean YAML-ready
+dicts and apply edited dicts back as strategic merge patches.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from system_operations_manager.tui.apps.kubernetes.types import ResourceType
+
+if TYPE_CHECKING:
+    from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+
+# Maps ResourceType -> (api_property, read_method, patch_method, is_namespaced)
+RESOURCE_API_MAP: dict[ResourceType, tuple[str, str, str, bool]] = {
+    ResourceType.DEPLOYMENTS: (
+        "apps_v1",
+        "read_namespaced_deployment",
+        "patch_namespaced_deployment",
+        True,
+    ),
+    ResourceType.STATEFULSETS: (
+        "apps_v1",
+        "read_namespaced_stateful_set",
+        "patch_namespaced_stateful_set",
+        True,
+    ),
+    ResourceType.DAEMONSETS: (
+        "apps_v1",
+        "read_namespaced_daemon_set",
+        "patch_namespaced_daemon_set",
+        True,
+    ),
+    ResourceType.SERVICES: (
+        "core_v1",
+        "read_namespaced_service",
+        "patch_namespaced_service",
+        True,
+    ),
+    ResourceType.INGRESSES: (
+        "networking_v1",
+        "read_namespaced_ingress",
+        "patch_namespaced_ingress",
+        True,
+    ),
+    ResourceType.NETWORK_POLICIES: (
+        "networking_v1",
+        "read_namespaced_network_policy",
+        "patch_namespaced_network_policy",
+        True,
+    ),
+    ResourceType.CONFIGMAPS: (
+        "core_v1",
+        "read_namespaced_config_map",
+        "patch_namespaced_config_map",
+        True,
+    ),
+    ResourceType.SECRETS: (
+        "core_v1",
+        "read_namespaced_secret",
+        "patch_namespaced_secret",
+        True,
+    ),
+    ResourceType.NAMESPACES: (
+        "core_v1",
+        "read_namespace",
+        "patch_namespace",
+        False,
+    ),
+}
+
+# Metadata fields managed by the server that should not be shown in the editor
+STRIP_METADATA_KEYS = frozenset(
+    {
+        "managedFields",
+        "resourceVersion",
+        "uid",
+        "creationTimestamp",
+        "generation",
+        "selfLink",
+        "deletionTimestamp",
+        "deletionGracePeriodSeconds",
+    }
+)
+
+
+def _strip_server_fields(obj_dict: dict[str, Any]) -> dict[str, Any]:
+    """Remove server-managed fields from a resource dict.
+
+    Strips the ``status`` block and server-managed metadata keys so the
+    user sees only the editable portion of the resource.
+    """
+    obj_dict.pop("status", None)
+    metadata = obj_dict.get("metadata", {})
+    if isinstance(metadata, dict):
+        for key in STRIP_METADATA_KEYS:
+            metadata.pop(key, None)
+    return obj_dict
+
+
+def fetch_raw_resource(
+    client: KubernetesClient,
+    resource_type: ResourceType,
+    name: str,
+    namespace: str | None,
+) -> dict[str, Any]:
+    """Fetch a raw Kubernetes object as a clean camelCase dict.
+
+    The returned dict has server-managed fields stripped and is suitable
+    for presenting in a YAML editor and round-tripping back through
+    :func:`apply_patch`.
+
+    Args:
+        client: Kubernetes API client.
+        resource_type: Type of resource to fetch.
+        name: Resource name.
+        namespace: Resource namespace (ignored for cluster-scoped types).
+
+    Returns:
+        Clean camelCase dict ready for YAML serialization.
+
+    Raises:
+        KeyError: If the resource type is not editable.
+        KubernetesError: If the API call fails.
+    """
+    from kubernetes.client import ApiClient
+
+    api_attr, read_method, _, is_namespaced = RESOURCE_API_MAP[resource_type]
+    api = getattr(client, api_attr)
+    read_fn = getattr(api, read_method)
+
+    if is_namespaced:
+        raw = read_fn(name=name, namespace=namespace or client.default_namespace)
+    else:
+        raw = read_fn(name=name)
+
+    # sanitize_for_serialization returns camelCase dict matching the K8s API
+    api_client = ApiClient()
+    obj_dict = api_client.sanitize_for_serialization(raw)
+
+    return _strip_server_fields(obj_dict)
+
+
+def apply_patch(
+    client: KubernetesClient,
+    resource_type: ResourceType,
+    name: str,
+    namespace: str | None,
+    patch_body: dict[str, Any],
+) -> None:
+    """Apply a strategic merge patch to a Kubernetes resource.
+
+    Args:
+        client: Kubernetes API client.
+        resource_type: Type of resource to patch.
+        name: Resource name.
+        namespace: Resource namespace (ignored for cluster-scoped types).
+        patch_body: camelCase dict to apply as a strategic merge patch.
+
+    Raises:
+        KeyError: If the resource type is not editable.
+        KubernetesError: If the API call fails.
+    """
+    api_attr, _, patch_method, is_namespaced = RESOURCE_API_MAP[resource_type]
+    api = getattr(client, api_attr)
+    patch_fn = getattr(api, patch_method)
+
+    if is_namespaced:
+        patch_fn(
+            name=name,
+            namespace=namespace or client.default_namespace,
+            body=patch_body,
+        )
+    else:
+        patch_fn(name=name, body=patch_body)

--- a/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
+++ b/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
@@ -211,3 +211,55 @@ DataTable > .datatable--cursor {
     height: auto;
     max-height: 100%;
 }
+
+/* ============================================ */
+/* Resource Create Screen Styles                */
+/* ============================================ */
+
+#create-header {
+    height: 3;
+    dock: top;
+    padding: 0 1;
+    text-style: bold;
+}
+
+#create-form {
+    padding: 1 2;
+    height: auto;
+}
+
+.form-field {
+    height: auto;
+    margin-bottom: 1;
+}
+
+.form-label {
+    margin-bottom: 0;
+}
+
+.form-help {
+    color: $text-muted;
+    margin-top: 0;
+}
+
+.form-field Input,
+.form-field Select {
+    width: 100%;
+}
+
+.form-field TextArea {
+    width: 100%;
+    height: 5;
+}
+
+#create-buttons {
+    dock: bottom;
+    height: 3;
+    align: center middle;
+    padding: 0 1;
+}
+
+#create-buttons Button {
+    margin: 0 1;
+    min-width: 12;
+}

--- a/src/system_operations_manager/tui/apps/kubernetes/types.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/types.py
@@ -44,3 +44,50 @@ CLUSTER_SCOPED_TYPES = frozenset(
 
 # Ordered list for cycling through types
 RESOURCE_TYPE_ORDER = list(ResourceType)
+
+# Resource types that support creation via the TUI
+CREATABLE_TYPES = frozenset(
+    {
+        ResourceType.DEPLOYMENTS,
+        ResourceType.STATEFULSETS,
+        ResourceType.DAEMONSETS,
+        ResourceType.SERVICES,
+        ResourceType.INGRESSES,
+        ResourceType.NETWORK_POLICIES,
+        ResourceType.CONFIGMAPS,
+        ResourceType.SECRETS,
+        ResourceType.NAMESPACES,
+    }
+)
+
+# Resource types that support editing (YAML patch) via the TUI
+EDITABLE_TYPES = frozenset(
+    {
+        ResourceType.DEPLOYMENTS,
+        ResourceType.STATEFULSETS,
+        ResourceType.DAEMONSETS,
+        ResourceType.SERVICES,
+        ResourceType.INGRESSES,
+        ResourceType.NETWORK_POLICIES,
+        ResourceType.CONFIGMAPS,
+        ResourceType.SECRETS,
+        ResourceType.NAMESPACES,
+    }
+)
+
+# Resource types that support deletion
+DELETABLE_TYPES = frozenset(
+    {
+        ResourceType.PODS,
+        ResourceType.DEPLOYMENTS,
+        ResourceType.STATEFULSETS,
+        ResourceType.DAEMONSETS,
+        ResourceType.REPLICASETS,
+        ResourceType.SERVICES,
+        ResourceType.INGRESSES,
+        ResourceType.NETWORK_POLICIES,
+        ResourceType.CONFIGMAPS,
+        ResourceType.SECRETS,
+        ResourceType.NAMESPACES,
+    }
+)

--- a/tests/unit/tui/apps/kubernetes/test_create_screen.py
+++ b/tests/unit/tui/apps/kubernetes/test_create_screen.py
@@ -1,0 +1,106 @@
+"""Unit tests for Kubernetes TUI resource create screen."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from system_operations_manager.tui.apps.kubernetes.create_screen import (
+    RESOURCE_FIELD_SPECS,
+    ResourceCreateScreen,
+    _parse_key_value_lines,
+    _parse_port_lines,
+)
+from system_operations_manager.tui.apps.kubernetes.types import (
+    CREATABLE_TYPES,
+    ResourceType,
+)
+
+
+class TestParseKeyValueLines:
+    @pytest.mark.unit
+    def test_parse_simple(self) -> None:
+        result = _parse_key_value_lines("key1=value1\nkey2=value2")
+        assert result == {"key1": "value1", "key2": "value2"}
+
+    @pytest.mark.unit
+    def test_parse_empty(self) -> None:
+        assert _parse_key_value_lines("") == {}
+
+    @pytest.mark.unit
+    def test_parse_skips_blank_lines(self) -> None:
+        result = _parse_key_value_lines("key1=value1\n\nkey2=value2\n")
+        assert result == {"key1": "value1", "key2": "value2"}
+
+    @pytest.mark.unit
+    def test_parse_skips_invalid_lines(self) -> None:
+        result = _parse_key_value_lines("key1=value1\ninvalid_line\nkey2=value2")
+        assert result == {"key1": "value1", "key2": "value2"}
+
+    @pytest.mark.unit
+    def test_parse_handles_equals_in_value(self) -> None:
+        result = _parse_key_value_lines("key=val=ue")
+        assert result == {"key": "val=ue"}
+
+
+class TestParsePortLines:
+    @pytest.mark.unit
+    def test_parse_simple_port(self) -> None:
+        result = _parse_port_lines("port=80")
+        assert len(result) == 1
+        assert result[0]["port"] == 80
+
+    @pytest.mark.unit
+    def test_parse_full_port(self) -> None:
+        result = _parse_port_lines("port=80,target_port=8080,protocol=TCP,name=http")
+        assert len(result) == 1
+        assert result[0] == {"port": 80, "target_port": 8080, "protocol": "TCP", "name": "http"}
+
+    @pytest.mark.unit
+    def test_parse_multiple_ports(self) -> None:
+        result = _parse_port_lines("port=80\nport=443")
+        assert len(result) == 2
+
+    @pytest.mark.unit
+    def test_parse_empty(self) -> None:
+        assert _parse_port_lines("") == []
+
+    @pytest.mark.unit
+    def test_parse_skips_lines_without_port(self) -> None:
+        result = _parse_port_lines("target_port=8080")
+        assert result == []
+
+
+class TestResourceFieldSpecs:
+    @pytest.mark.unit
+    def test_all_creatable_types_have_specs(self) -> None:
+        for rt in CREATABLE_TYPES:
+            assert rt in RESOURCE_FIELD_SPECS, f"{rt} missing from RESOURCE_FIELD_SPECS"
+
+    @pytest.mark.unit
+    def test_each_type_has_name_field(self) -> None:
+        for rt, specs in RESOURCE_FIELD_SPECS.items():
+            names = [s.name for s in specs]
+            assert "name" in names, f"{rt} missing 'name' field"
+
+    @pytest.mark.unit
+    def test_name_field_is_required(self) -> None:
+        for rt, specs in RESOURCE_FIELD_SPECS.items():
+            name_spec = next(s for s in specs if s.name == "name")
+            assert name_spec.required, f"{rt} 'name' field should be required"
+
+
+class TestResourceCreateScreen:
+    @pytest.mark.unit
+    def test_screen_stores_resource_type(self) -> None:
+        mock_client = MagicMock()
+        mock_client.default_namespace = "default"
+        screen = ResourceCreateScreen(ResourceType.DEPLOYMENTS, mock_client)
+        assert screen._resource_type == ResourceType.DEPLOYMENTS
+
+    @pytest.mark.unit
+    def test_resource_created_message(self) -> None:
+        msg = ResourceCreateScreen.ResourceCreated(ResourceType.PODS, "test-pod")
+        assert msg.resource_type == ResourceType.PODS
+        assert msg.resource_name == "test-pod"

--- a/tests/unit/tui/apps/kubernetes/test_delete_helpers.py
+++ b/tests/unit/tui/apps/kubernetes/test_delete_helpers.py
@@ -1,0 +1,67 @@
+"""Unit tests for Kubernetes TUI delete helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from system_operations_manager.tui.apps.kubernetes.delete_helpers import (
+    RESOURCE_DELETE_MAP,
+    delete_resource,
+)
+from system_operations_manager.tui.apps.kubernetes.types import (
+    DELETABLE_TYPES,
+    ResourceType,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.default_namespace = "default"
+    return mock
+
+
+class TestDeleteHelpers:
+    @pytest.mark.unit
+    def test_all_deletable_types_in_map(self) -> None:
+        """Every DELETABLE_TYPE should have an entry in RESOURCE_DELETE_MAP."""
+        for rt in DELETABLE_TYPES:
+            assert rt in RESOURCE_DELETE_MAP, f"{rt} missing from RESOURCE_DELETE_MAP"
+
+    @pytest.mark.unit
+    def test_delete_namespaced_resource(self, mock_client: MagicMock) -> None:
+        """Should call the correct namespaced delete method."""
+        delete_resource(mock_client, ResourceType.PODS, "my-pod", "test-ns")
+        mock_client.core_v1.delete_namespaced_pod.assert_called_once_with(
+            name="my-pod", namespace="test-ns"
+        )
+
+    @pytest.mark.unit
+    def test_delete_cluster_scoped_resource(self, mock_client: MagicMock) -> None:
+        """Should call the correct cluster-scoped delete method."""
+        delete_resource(mock_client, ResourceType.NAMESPACES, "my-ns", None)
+        mock_client.core_v1.delete_namespace.assert_called_once_with(name="my-ns")
+
+    @pytest.mark.unit
+    def test_delete_deployment(self, mock_client: MagicMock) -> None:
+        """Should call apps_v1 for deployment deletion."""
+        delete_resource(mock_client, ResourceType.DEPLOYMENTS, "my-deploy", "default")
+        mock_client.apps_v1.delete_namespaced_deployment.assert_called_once_with(
+            name="my-deploy", namespace="default"
+        )
+
+    @pytest.mark.unit
+    def test_delete_uses_default_namespace_when_none(self, mock_client: MagicMock) -> None:
+        """Should fall back to client's default namespace."""
+        delete_resource(mock_client, ResourceType.CONFIGMAPS, "my-cm", None)
+        mock_client.core_v1.delete_namespaced_config_map.assert_called_once_with(
+            name="my-cm", namespace="default"
+        )
+
+    @pytest.mark.unit
+    def test_delete_unsupported_type_raises(self, mock_client: MagicMock) -> None:
+        """Should raise KeyError for types not in the map."""
+        with pytest.raises(KeyError):
+            delete_resource(mock_client, ResourceType.NODES, "my-node", None)

--- a/tests/unit/tui/apps/kubernetes/test_edit_helpers.py
+++ b/tests/unit/tui/apps/kubernetes/test_edit_helpers.py
@@ -1,0 +1,109 @@
+"""Unit tests for Kubernetes TUI edit helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from system_operations_manager.tui.apps.kubernetes.edit_helpers import (
+    RESOURCE_API_MAP,
+    _strip_server_fields,
+    apply_patch,
+    fetch_raw_resource,
+)
+from system_operations_manager.tui.apps.kubernetes.types import (
+    EDITABLE_TYPES,
+    ResourceType,
+)
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.default_namespace = "default"
+    return mock
+
+
+class TestStripServerFields:
+    @pytest.mark.unit
+    def test_strips_status(self) -> None:
+        obj = {"metadata": {"name": "test"}, "spec": {}, "status": {"phase": "Running"}}
+        result = _strip_server_fields(obj)
+        assert "status" not in result
+
+    @pytest.mark.unit
+    def test_strips_managed_fields(self) -> None:
+        obj = {"metadata": {"name": "test", "managedFields": [{}], "uid": "abc123"}}
+        result = _strip_server_fields(obj)
+        assert "managedFields" not in result["metadata"]
+        assert "uid" not in result["metadata"]
+
+    @pytest.mark.unit
+    def test_preserves_user_fields(self) -> None:
+        obj = {"metadata": {"name": "test", "labels": {"app": "foo"}}, "spec": {"replicas": 3}}
+        result = _strip_server_fields(obj)
+        assert result["metadata"]["name"] == "test"
+        assert result["metadata"]["labels"] == {"app": "foo"}
+        assert result["spec"]["replicas"] == 3
+
+
+class TestResourceApiMap:
+    @pytest.mark.unit
+    def test_all_editable_types_in_map(self) -> None:
+        for rt in EDITABLE_TYPES:
+            assert rt in RESOURCE_API_MAP, f"{rt} missing from RESOURCE_API_MAP"
+
+
+class TestFetchRawResource:
+    @pytest.mark.unit
+    def test_fetch_namespaced(self, mock_client: MagicMock) -> None:
+        mock_raw = MagicMock()
+        mock_client.apps_v1.read_namespaced_deployment.return_value = mock_raw
+
+        with patch("kubernetes.client.ApiClient") as mock_api_client_cls:
+            mock_api_client = MagicMock()
+            mock_api_client.sanitize_for_serialization.return_value = {
+                "metadata": {"name": "test", "managedFields": [{}]},
+                "spec": {},
+                "status": {},
+            }
+            mock_api_client_cls.return_value = mock_api_client
+
+            result = fetch_raw_resource(mock_client, ResourceType.DEPLOYMENTS, "test", "default")
+
+            assert "status" not in result
+            assert "managedFields" not in result.get("metadata", {})
+
+    @pytest.mark.unit
+    def test_fetch_cluster_scoped(self, mock_client: MagicMock) -> None:
+        mock_raw = MagicMock()
+        mock_client.core_v1.read_namespace.return_value = mock_raw
+
+        with patch("kubernetes.client.ApiClient") as mock_api_client_cls:
+            mock_api_client = MagicMock()
+            mock_api_client.sanitize_for_serialization.return_value = {
+                "metadata": {"name": "test"},
+            }
+            mock_api_client_cls.return_value = mock_api_client
+
+            result = fetch_raw_resource(mock_client, ResourceType.NAMESPACES, "test", None)
+
+            mock_client.core_v1.read_namespace.assert_called_once_with(name="test")
+            assert result["metadata"]["name"] == "test"
+
+
+class TestApplyPatch:
+    @pytest.mark.unit
+    def test_apply_namespaced(self, mock_client: MagicMock) -> None:
+        patch_body = {"spec": {"replicas": 5}}
+        apply_patch(mock_client, ResourceType.DEPLOYMENTS, "test", "default", patch_body)
+        mock_client.apps_v1.patch_namespaced_deployment.assert_called_once_with(
+            name="test", namespace="default", body=patch_body
+        )
+
+    @pytest.mark.unit
+    def test_apply_cluster_scoped(self, mock_client: MagicMock) -> None:
+        patch_body = {"metadata": {"labels": {"env": "test"}}}
+        apply_patch(mock_client, ResourceType.NAMESPACES, "test", None, patch_body)
+        mock_client.core_v1.patch_namespace.assert_called_once_with(name="test", body=patch_body)


### PR DESCRIPTION
## Summary
- Add create, edit, and delete operations to the Kubernetes TUI
- Fill service layer gaps with `update_secret()`, `update_network_policy()`, and `update_namespace()` methods
- Form-based creation for all 9 creatable resource types, YAML editor via `$EDITOR` with `app.suspend()`, and delete with Modal confirmation

## Task
Closes beads task `system-operations-manager-t9c`: TUI CRUD operations

## Changes
- `src/system_operations_manager/services/kubernetes/configuration_manager.py` - Add `update_secret()`
- `src/system_operations_manager/services/kubernetes/networking_manager.py` - Add `update_network_policy()`
- `src/system_operations_manager/services/kubernetes/namespace_manager.py` - Add `update_namespace()`
- `src/system_operations_manager/tui/apps/kubernetes/types.py` - Add CREATABLE/EDITABLE/DELETABLE_TYPES constants
- `src/system_operations_manager/tui/apps/kubernetes/create_screen.py` - New form-based ResourceCreateScreen with FieldSpec registry
- `src/system_operations_manager/tui/apps/kubernetes/edit_helpers.py` - New YAML fetch/patch helpers for editor flow
- `src/system_operations_manager/tui/apps/kubernetes/delete_helpers.py` - New resource deletion dispatch helpers
- `src/system_operations_manager/tui/apps/kubernetes/screens.py` - Wire up `a`(create), `d`(delete), `e`(edit) keybindings
- `src/system_operations_manager/tui/apps/kubernetes/app.py` - Update help text
- `src/system_operations_manager/tui/apps/kubernetes/styles.tcss` - Create form styles
- `tests/unit/` - 35 new tests across 6 test files

## Validation
- [x] All tests pass (3560 passed)
- [x] Lint clean
- [x] Format clean
- [x] Manual review of implementation checklist

Generated with [Claude Code](https://claude.com/claude-code)