### PR TITLE
system-operations-manager-6a4: TUI log viewer and exec for K8s pods

### DIFF
--- a/src/system_operations_manager/tui/apps/kubernetes/app.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/app.py
@@ -94,7 +94,7 @@ class KubernetesApp(App[None]):
         self.notify(
             "j/k: navigate | Enter: select | n/N: namespace | "
             "c/C: cluster | f/F: resource type | r: refresh | "
-            "a: create | d: delete | e: edit | q: quit"
+            "a: create | d: delete | e: edit | l: logs | x: exec | q: quit"
         )
 
     @on(ResourceListScreen.ResourceSelected)

--- a/src/system_operations_manager/tui/apps/kubernetes/log_viewer.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/log_viewer.py
@@ -1,0 +1,293 @@
+"""Log viewer screen for Kubernetes pod log streaming.
+
+Provides a TUI screen with real-time log streaming via RichLog,
+container selection for multi-container pods, and follow/pause controls.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.widgets import Label, RichLog
+
+from system_operations_manager.tui.apps.kubernetes.widgets import SelectorPopup
+from system_operations_manager.tui.base import BaseScreen
+
+if TYPE_CHECKING:
+    from textual.worker import Worker
+
+    from system_operations_manager.integrations.kubernetes.client import KubernetesClient
+    from system_operations_manager.integrations.kubernetes.models.workloads import PodSummary
+    from system_operations_manager.services.kubernetes.streaming_manager import (
+        StreamingManager,
+    )
+
+logger = structlog.get_logger()
+
+TAIL_LINES_FOLLOW = 200
+TAIL_LINES_STATIC = 500
+
+
+class LogViewerScreen(BaseScreen[None]):
+    """Screen for viewing pod logs with streaming support.
+
+    Displays logs from a selected container using Textual's RichLog
+    widget. Supports follow mode for real-time streaming, container
+    switching, and timestamp toggling.
+
+    Args:
+        resource: Pod to view logs for.
+        client: Kubernetes API client.
+        initial_container: Container name to start with (defaults to first).
+    """
+
+    BINDINGS = [
+        ("escape", "back", "Back"),
+        ("c", "select_container", "Container"),
+        ("f", "toggle_follow", "Follow"),
+        ("space", "toggle_follow", "Pause/Resume"),
+        ("t", "toggle_timestamps", "Timestamps"),
+        ("ctrl+l", "clear_logs", "Clear"),
+        ("g", "scroll_top", "Top"),
+        ("G", "scroll_bottom", "Bottom"),
+    ]
+
+    def __init__(
+        self,
+        resource: PodSummary,
+        client: KubernetesClient,
+        initial_container: str | None = None,
+    ) -> None:
+        """Initialize the log viewer screen.
+
+        Args:
+            resource: The pod resource to stream logs from.
+            client: Kubernetes API client for streaming.
+            initial_container: Container name to view (defaults to first).
+        """
+        super().__init__()
+        self._resource = resource
+        self._client = client
+        self._container = initial_container
+        self._following = True
+        self._show_timestamps = False
+        self.__streaming_mgr: StreamingManager | None = None
+        self._log_worker: Worker[None] | None = None
+
+    @property
+    def _streaming_mgr(self) -> StreamingManager:
+        """Lazy-loaded streaming manager instance."""
+        if self.__streaming_mgr is None:
+            from system_operations_manager.services.kubernetes.streaming_manager import (
+                StreamingManager,
+            )
+
+            self.__streaming_mgr = StreamingManager(self._client)
+        return self.__streaming_mgr
+
+    # =========================================================================
+    # Layout
+    # =========================================================================
+
+    def compose(self) -> ComposeResult:
+        """Compose the log viewer layout."""
+        yield Container(
+            Label(self._build_header(), id="log-header"),
+            Horizontal(
+                Label(self._build_container_label(), id="log-container-label"),
+                Label("[bold green]FOLLOWING[/bold green]", id="log-status"),
+                id="log-toolbar",
+            ),
+            RichLog(
+                highlight=True,
+                markup=True,
+                auto_scroll=True,
+                id="log-output",
+            ),
+            id="log-container",
+        )
+
+    def on_mount(self) -> None:
+        """Set default container and start streaming."""
+        if not self._container and self._resource.containers:
+            self._container = self._resource.containers[0].name
+            self.query_one("#log-container-label", Label).update(self._build_container_label())
+        self._start_log_stream()
+
+    # =========================================================================
+    # Text Builders
+    # =========================================================================
+
+    def _build_header(self) -> str:
+        """Build the header text with pod name and namespace.
+
+        Returns:
+            Rich-markup formatted header string.
+        """
+        name = self._resource.name
+        ns = self._resource.namespace
+        parts = [f"[bold]Pod Logs[/bold] / [bold cyan]{name}[/bold cyan]"]
+        if ns:
+            parts.append(f"  [dim]ns:[/dim] {ns}")
+        return "".join(parts)
+
+    def _build_container_label(self) -> str:
+        """Build the container label text.
+
+        Returns:
+            Formatted container label string.
+        """
+        display = self._container or "N/A"
+        return f"Container: [bold]{display}[/bold]"
+
+    # =========================================================================
+    # Log Streaming
+    # =========================================================================
+
+    def _start_log_stream(self) -> None:
+        """Cancel existing worker and start a new log stream."""
+        self._cancel_log_worker()
+        if self._following:
+            self._log_worker = self._stream_follow_logs()
+        else:
+            self._log_worker = self._load_static_logs()
+
+    @work(thread=True)
+    def _stream_follow_logs(self) -> None:
+        """Stream logs in follow mode using a background thread.
+
+        Uses ``StreamingManager.stream_logs(follow=True)`` which returns
+        a blocking iterator. Lines are posted to the UI thread via
+        ``call_from_thread``.
+        """
+        log_widget = self.query_one("#log-output", RichLog)
+        try:
+            iterator = self._streaming_mgr.stream_logs(
+                self._resource.name,
+                self._resource.namespace,
+                container=self._container,
+                follow=True,
+                tail_lines=TAIL_LINES_FOLLOW,
+                timestamps=self._show_timestamps,
+            )
+            if isinstance(iterator, str):
+                # Shouldn't happen with follow=True but handle gracefully
+                for line in iterator.splitlines():
+                    self.app.call_from_thread(log_widget.write, line)
+                return
+
+            for line in iterator:
+                self.app.call_from_thread(log_widget.write, line.rstrip("\n"))
+        except Exception as e:
+            logger.warning("log_stream_error", pod=self._resource.name, error=str(e))
+            self.app.call_from_thread(
+                log_widget.write,
+                f"[red]Error streaming logs: {e}[/red]",
+            )
+
+    @work(thread=True)
+    def _load_static_logs(self) -> None:
+        """Load logs in non-follow mode (snapshot).
+
+        Fetches all available log lines and writes them to the RichLog.
+        """
+        log_widget = self.query_one("#log-output", RichLog)
+        try:
+            result = self._streaming_mgr.stream_logs(
+                self._resource.name,
+                self._resource.namespace,
+                container=self._container,
+                follow=False,
+                tail_lines=TAIL_LINES_STATIC,
+                timestamps=self._show_timestamps,
+            )
+            if isinstance(result, str):
+                for line in result.splitlines():
+                    self.app.call_from_thread(log_widget.write, line)
+            else:
+                for line in result:
+                    self.app.call_from_thread(log_widget.write, line.rstrip("\n"))
+        except Exception as e:
+            logger.warning("log_load_error", pod=self._resource.name, error=str(e))
+            self.app.call_from_thread(
+                log_widget.write,
+                f"[red]Error loading logs: {e}[/red]",
+            )
+
+    def _cancel_log_worker(self) -> None:
+        """Cancel the active log streaming worker if running."""
+        if self._log_worker is not None and self._log_worker.is_running:
+            self._log_worker.cancel()
+            self._log_worker = None
+
+    # =========================================================================
+    # Keyboard Actions
+    # =========================================================================
+
+    def action_back(self) -> None:
+        """Cancel streaming and navigate back."""
+        self._cancel_log_worker()
+        self.go_back()
+
+    def action_select_container(self) -> None:
+        """Open container selector popup."""
+        containers = [c.name for c in self._resource.containers if c.name]
+        if not containers:
+            self.notify_user("No containers found", severity="warning")
+            return
+        self.app.push_screen(
+            SelectorPopup("Select Container", containers, self._container),
+            callback=self._handle_container_selected,
+        )
+
+    def _handle_container_selected(self, result: str | None) -> None:
+        """Handle container selection from popup.
+
+        Args:
+            result: Selected container name or None if dismissed.
+        """
+        if result and result != self._container:
+            self._container = result
+            self.query_one("#log-container-label", Label).update(self._build_container_label())
+            log_widget = self.query_one("#log-output", RichLog)
+            log_widget.clear()
+            self._start_log_stream()
+
+    def action_toggle_follow(self) -> None:
+        """Toggle between follow and paused mode."""
+        self._following = not self._following
+        status = self.query_one("#log-status", Label)
+        if self._following:
+            status.update("[bold green]FOLLOWING[/bold green]")
+            self._start_log_stream()
+        else:
+            status.update("[bold yellow]PAUSED[/bold yellow]")
+            self._cancel_log_worker()
+
+    def action_toggle_timestamps(self) -> None:
+        """Toggle timestamp display and restart stream."""
+        self._show_timestamps = not self._show_timestamps
+        state = "on" if self._show_timestamps else "off"
+        self.notify_user(f"Timestamps {state}")
+        log_widget = self.query_one("#log-output", RichLog)
+        log_widget.clear()
+        self._start_log_stream()
+
+    def action_clear_logs(self) -> None:
+        """Clear the log output."""
+        log_widget = self.query_one("#log-output", RichLog)
+        log_widget.clear()
+
+    def action_scroll_top(self) -> None:
+        """Scroll to the top of the log output."""
+        log_widget = self.query_one("#log-output", RichLog)
+        log_widget.scroll_home()
+
+    def action_scroll_bottom(self) -> None:
+        """Scroll to the bottom of the log output."""
+        log_widget = self.query_one("#log-output", RichLog)
+        log_widget.scroll_end()

--- a/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
+++ b/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
@@ -263,3 +263,40 @@ DataTable > .datatable--cursor {
     margin: 0 1;
     min-width: 12;
 }
+
+/* ============================================ */
+/* Log Viewer Screen                            */
+/* ============================================ */
+
+#log-container {
+    padding: 1;
+}
+
+#log-header {
+    height: 3;
+    dock: top;
+    padding: 0 1;
+    text-style: bold;
+}
+
+#log-toolbar {
+    height: 3;
+    dock: top;
+    padding: 0 1;
+}
+
+#log-toolbar #log-container-label {
+    width: 1fr;
+}
+
+#log-toolbar #log-status {
+    width: auto;
+    margin-left: 2;
+}
+
+#log-output {
+    height: 1fr;
+    border: solid $primary;
+    padding: 1;
+    scrollbar-gutter: stable;
+}

--- a/tests/unit/tui/apps/kubernetes/test_log_viewer.py
+++ b/tests/unit/tui/apps/kubernetes/test_log_viewer.py
@@ -1,0 +1,274 @@
+"""Unit tests for Kubernetes TUI log viewer screen.
+
+Tests LogViewerScreen bindings, constructor, header building,
+and default state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.binding import Binding
+
+from system_operations_manager.integrations.kubernetes.models.workloads import (
+    ContainerStatus,
+    PodSummary,
+)
+from system_operations_manager.tui.apps.kubernetes.log_viewer import (
+    TAIL_LINES_FOLLOW,
+    TAIL_LINES_STATIC,
+    LogViewerScreen,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture()
+def sample_pod_with_containers() -> PodSummary:
+    """Create a sample pod with multiple containers."""
+    return PodSummary(
+        name="nginx-abc123",
+        namespace="default",
+        phase="Running",
+        ready_count=2,
+        total_count=2,
+        restarts=0,
+        containers=[
+            ContainerStatus(name="nginx", image="nginx:1.25", ready=True, state="running"),
+            ContainerStatus(name="sidecar", image="envoy:latest", ready=True, state="running"),
+        ],
+    )
+
+
+@pytest.fixture()
+def sample_pod_single_container() -> PodSummary:
+    """Create a sample pod with one container."""
+    return PodSummary(
+        name="simple-pod",
+        namespace="default",
+        phase="Running",
+        ready_count=1,
+        total_count=1,
+        restarts=0,
+        containers=[
+            ContainerStatus(name="app", image="myapp:1.0", ready=True, state="running"),
+        ],
+    )
+
+
+# ============================================================================
+# Binding Tests
+# ============================================================================
+
+
+def _binding_keys() -> list[str]:
+    """Extract binding key strings from LogViewerScreen."""
+    return [b.key if isinstance(b, Binding) else b[0] for b in LogViewerScreen.BINDINGS]
+
+
+class TestLogViewerBindings:
+    """Tests for LogViewerScreen key bindings."""
+
+    @pytest.mark.unit
+    def test_has_bindings(self) -> None:
+        """Screen defines bindings."""
+        assert len(LogViewerScreen.BINDINGS) > 0
+
+    @pytest.mark.unit
+    def test_escape_binding(self) -> None:
+        """Escape navigates back."""
+        assert "escape" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_container_select_binding(self) -> None:
+        """'c' opens container selector."""
+        assert "c" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_follow_toggle_binding(self) -> None:
+        """'f' toggles follow mode."""
+        assert "f" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_space_toggle_binding(self) -> None:
+        """Space toggles follow mode."""
+        assert "space" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_timestamps_binding(self) -> None:
+        """'t' toggles timestamps."""
+        assert "t" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_clear_binding(self) -> None:
+        """Ctrl+L clears log output."""
+        assert "ctrl+l" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_scroll_top_binding(self) -> None:
+        """'g' scrolls to top."""
+        assert "g" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_scroll_bottom_binding(self) -> None:
+        """'G' scrolls to bottom."""
+        assert "G" in _binding_keys()
+
+
+# ============================================================================
+# Constructor Tests
+# ============================================================================
+
+
+class TestLogViewerConstructor:
+    """Tests for LogViewerScreen initialization."""
+
+    @pytest.mark.unit
+    def test_stores_resource(self, sample_pod_with_containers: PodSummary) -> None:
+        """Constructor stores the pod resource."""
+        client = MagicMock()
+        screen = LogViewerScreen(resource=sample_pod_with_containers, client=client)
+        assert screen._resource.name == "nginx-abc123"
+
+    @pytest.mark.unit
+    def test_stores_client(self, sample_pod_with_containers: PodSummary) -> None:
+        """Constructor stores the K8s client."""
+        client = MagicMock()
+        screen = LogViewerScreen(resource=sample_pod_with_containers, client=client)
+        assert screen._client is client
+
+    @pytest.mark.unit
+    def test_container_defaults_to_none(self, sample_pod_with_containers: PodSummary) -> None:
+        """Container is None before mount (set during on_mount)."""
+        client = MagicMock()
+        screen = LogViewerScreen(resource=sample_pod_with_containers, client=client)
+        assert screen._container is None
+
+    @pytest.mark.unit
+    def test_initial_container_parameter(self, sample_pod_with_containers: PodSummary) -> None:
+        """initial_container parameter sets starting container."""
+        client = MagicMock()
+        screen = LogViewerScreen(
+            resource=sample_pod_with_containers,
+            client=client,
+            initial_container="sidecar",
+        )
+        assert screen._container == "sidecar"
+
+    @pytest.mark.unit
+    def test_following_defaults_true(self, sample_pod_with_containers: PodSummary) -> None:
+        """Follow mode is enabled by default."""
+        client = MagicMock()
+        screen = LogViewerScreen(resource=sample_pod_with_containers, client=client)
+        assert screen._following is True
+
+    @pytest.mark.unit
+    def test_timestamps_defaults_false(self, sample_pod_with_containers: PodSummary) -> None:
+        """Timestamp display is disabled by default."""
+        client = MagicMock()
+        screen = LogViewerScreen(resource=sample_pod_with_containers, client=client)
+        assert screen._show_timestamps is False
+
+
+# ============================================================================
+# Header Builder Tests
+# ============================================================================
+
+
+class TestLogViewerHeader:
+    """Tests for _build_header text generation."""
+
+    @pytest.mark.unit
+    def test_header_includes_pod_name(self, sample_pod_with_containers: PodSummary) -> None:
+        """Header contains the pod name."""
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._resource = sample_pod_with_containers
+        header = screen._build_header()
+        assert "nginx-abc123" in header
+
+    @pytest.mark.unit
+    def test_header_includes_namespace(self, sample_pod_with_containers: PodSummary) -> None:
+        """Header contains the namespace."""
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._resource = sample_pod_with_containers
+        header = screen._build_header()
+        assert "default" in header
+        assert "ns:" in header
+
+    @pytest.mark.unit
+    def test_header_no_namespace(self) -> None:
+        """Header omits namespace section when None."""
+        pod = PodSummary(
+            name="orphan-pod",
+            namespace=None,
+            phase="Running",
+            ready_count=1,
+            total_count=1,
+            restarts=0,
+        )
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._resource = pod
+        header = screen._build_header()
+        assert "orphan-pod" in header
+        assert "ns:" not in header
+
+    @pytest.mark.unit
+    def test_header_includes_label(self, sample_pod_with_containers: PodSummary) -> None:
+        """Header includes 'Pod Logs' label."""
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._resource = sample_pod_with_containers
+        header = screen._build_header()
+        assert "Pod Logs" in header
+
+
+# ============================================================================
+# Container Label Tests
+# ============================================================================
+
+
+class TestLogViewerContainerLabel:
+    """Tests for _build_container_label text generation."""
+
+    @pytest.mark.unit
+    def test_label_with_container(self) -> None:
+        """Label shows container name."""
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._container = "nginx"
+        label = screen._build_container_label()
+        assert "nginx" in label
+        assert "Container:" in label
+
+    @pytest.mark.unit
+    def test_label_without_container(self) -> None:
+        """Label shows N/A when no container set."""
+        screen = LogViewerScreen.__new__(LogViewerScreen)
+        screen._container = None
+        label = screen._build_container_label()
+        assert "N/A" in label
+
+
+# ============================================================================
+# Constants Tests
+# ============================================================================
+
+
+class TestLogViewerConstants:
+    """Tests for log viewer constants."""
+
+    @pytest.mark.unit
+    def test_tail_lines_follow_is_positive(self) -> None:
+        """Follow tail lines is a positive integer."""
+        assert TAIL_LINES_FOLLOW > 0
+
+    @pytest.mark.unit
+    def test_tail_lines_static_is_positive(self) -> None:
+        """Static tail lines is a positive integer."""
+        assert TAIL_LINES_STATIC > 0
+
+    @pytest.mark.unit
+    def test_static_tail_greater_than_follow(self) -> None:
+        """Static mode fetches more lines than follow mode."""
+        assert TAIL_LINES_STATIC >= TAIL_LINES_FOLLOW

--- a/tests/unit/tui/apps/kubernetes/test_screens.py
+++ b/tests/unit/tui/apps/kubernetes/test_screens.py
@@ -399,6 +399,14 @@ class TestResourceListScreen:
         assert "r" in binding_keys
 
     @pytest.mark.unit
+    def test_screen_bindings_include_logs(self) -> None:
+        """Screen bindings include logs shortcut."""
+        binding_keys = [
+            b.key if isinstance(b, Binding) else b[0] for b in ResourceListScreen.BINDINGS
+        ]
+        assert "l" in binding_keys
+
+    @pytest.mark.unit
     def test_resource_selected_message(self) -> None:
         """ResourceSelected message stores resource and type."""
         pod = PodSummary(name="test", phase="Running", ready_count=1, total_count=1, restarts=0)
@@ -496,6 +504,22 @@ class TestResourceDetailScreen:
             b.key if isinstance(b, Binding) else b[0] for b in ResourceDetailScreen.BINDINGS
         ]
         assert "r" in binding_keys
+
+    @pytest.mark.unit
+    def test_screen_bindings_include_logs(self) -> None:
+        """Screen bindings include l for logs."""
+        binding_keys = [
+            b.key if isinstance(b, Binding) else b[0] for b in ResourceDetailScreen.BINDINGS
+        ]
+        assert "l" in binding_keys
+
+    @pytest.mark.unit
+    def test_screen_bindings_include_exec(self) -> None:
+        """Screen bindings include x for exec."""
+        binding_keys = [
+            b.key if isinstance(b, Binding) else b[0] for b in ResourceDetailScreen.BINDINGS
+        ]
+        assert "x" in binding_keys
 
     @pytest.mark.unit
     def test_status_color_map_has_common_statuses(self) -> None:


### PR DESCRIPTION
## Summary
- Add `LogViewerScreen` with real-time pod log streaming via Textual's `RichLog` widget, container selector for multi-container pods, follow/pause toggle, timestamp display, and clear functionality
- Add exec action on `ResourceDetailScreen` that suspends the TUI for interactive shell sessions using raw terminal mode
- Wire up `l` (logs) and `x` (exec) bindings to `ResourceDetailScreen` and `l` to `ResourceListScreen`

## Task
Closes beads task `system-operations-manager-6a4`: TUI log viewer and exec

## Changes
- `src/.../tui/apps/kubernetes/log_viewer.py` — New `LogViewerScreen` with `@work(thread=True)` streaming, `SelectorPopup` container picker, follow/pause/timestamps/clear controls
- `src/.../tui/apps/kubernetes/screens.py` — Add `l`/`x` bindings and action methods to `ResourceDetailScreen`; add `l` binding to `ResourceListScreen`
- `src/.../tui/apps/kubernetes/styles.tcss` — Add log viewer CSS section
- `src/.../tui/apps/kubernetes/app.py` — Update help text with new shortcuts
- `tests/.../test_log_viewer.py` — Unit tests for bindings, constructor, header/label builders, constants
- `tests/.../test_screens.py` — Add binding presence tests for `l`/`x`

## Validation
- [x] All 3587 tests pass (74 skipped)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] All pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)