### PR TITLE
system-operations-manager-10r: TUI ecosystem tools overview screen

### DIFF
--- a/src/system_operations_manager/tui/apps/kubernetes/app.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/app.py
@@ -13,6 +13,9 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import Footer, Header
 
+from system_operations_manager.tui.apps.kubernetes.ecosystem_screen import (
+    EcosystemScreen,
+)
 from system_operations_manager.tui.apps.kubernetes.screens import (
     DashboardScreen,
     ResourceDetailScreen,
@@ -32,6 +35,7 @@ __all__ = [
     "CLUSTER_SCOPED_TYPES",
     "RESOURCE_TYPE_ORDER",
     "DashboardScreen",
+    "EcosystemScreen",
     "KubernetesApp",
     "ResourceDetailScreen",
     "ResourceType",
@@ -55,6 +59,7 @@ class KubernetesApp(App[None]):
         Binding("q", "quit", "Quit", show=True),
         Binding("escape", "back", "Back", show=True),
         Binding("d", "dashboard", "Dashboard", show=True),
+        Binding("e", "ecosystem", "Ecosystem", show=True),
         Binding("question_mark", "help", "Help", show=True),
     ]
 
@@ -89,12 +94,16 @@ class KubernetesApp(App[None]):
         """Open the cluster status dashboard."""
         self.push_screen(DashboardScreen(client=self._client))
 
+    def action_ecosystem(self) -> None:
+        """Open the ecosystem tools overview."""
+        self.push_screen(EcosystemScreen(client=self._client))
+
     def action_help(self) -> None:
         """Show keyboard shortcut help."""
         self.notify(
             "j/k: navigate | Enter: select | n/N: namespace | "
             "c/C: cluster | f/F: resource type | r: refresh | "
-            "a: create | d: delete | e: edit | l: logs | x: exec | q: quit"
+            "a: create | d: delete | e: ecosystem | l: logs | x: exec | q: quit"
         )
 
     @on(ResourceListScreen.ResourceSelected)

--- a/src/system_operations_manager/tui/apps/kubernetes/ecosystem_screen.py
+++ b/src/system_operations_manager/tui/apps/kubernetes/ecosystem_screen.py
@@ -1,0 +1,602 @@
+"""Ecosystem tools overview screen for the Kubernetes TUI.
+
+Displays status panels for ArgoCD applications, Flux CD resources,
+Cert-Manager certificates, and Argo Rollouts in a unified dashboard.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.widgets import DataTable, Label
+
+from system_operations_manager.integrations.kubernetes.exceptions import (
+    KubernetesNotFoundError,
+)
+from system_operations_manager.tui.apps.kubernetes.widgets import RefreshTimer
+from system_operations_manager.tui.base import BaseScreen
+
+if TYPE_CHECKING:
+    from system_operations_manager.integrations.kubernetes.client import (
+        KubernetesClient,
+    )
+    from system_operations_manager.services.kubernetes.argocd_manager import (
+        ArgoCDManager,
+    )
+    from system_operations_manager.services.kubernetes.certmanager_manager import (
+        CertManagerManager,
+    )
+    from system_operations_manager.services.kubernetes.flux_manager import FluxManager
+    from system_operations_manager.services.kubernetes.rollouts_manager import (
+        RolloutsManager,
+    )
+
+logger = structlog.get_logger()
+
+# ============================================================================
+# Column Definitions
+# ============================================================================
+
+ARGOCD_COLUMNS: list[tuple[str, int]] = [
+    ("Name", 25),
+    ("Namespace", 15),
+    ("Project", 12),
+    ("Sync", 10),
+    ("Health", 10),
+    ("Repo", 30),
+]
+
+FLUX_COLUMNS: list[tuple[str, int]] = [
+    ("Name", 25),
+    ("Namespace", 15),
+    ("Type", 12),
+    ("Ready", 8),
+    ("Status", 15),
+    ("Revision", 20),
+]
+
+CERT_COLUMNS: list[tuple[str, int]] = [
+    ("Name", 25),
+    ("Namespace", 15),
+    ("Ready", 8),
+    ("Expiry", 20),
+    ("Issuer", 20),
+    ("DNS Names", 25),
+]
+
+ROLLOUT_COLUMNS: list[tuple[str, int]] = [
+    ("Name", 25),
+    ("Namespace", 15),
+    ("Strategy", 10),
+    ("Phase", 12),
+    ("Ready", 10),
+    ("Weight", 8),
+]
+
+# ============================================================================
+# Color Maps
+# ============================================================================
+
+SYNC_STATUS_COLORS: dict[str, str] = {
+    "Synced": "green",
+    "OutOfSync": "yellow",
+    "Unknown": "dim",
+}
+
+HEALTH_STATUS_COLORS: dict[str, str] = {
+    "Healthy": "green",
+    "Degraded": "red",
+    "Progressing": "yellow",
+    "Suspended": "dim",
+    "Missing": "red",
+    "Unknown": "dim",
+}
+
+PHASE_COLORS: dict[str, str] = {
+    "Healthy": "green",
+    "Paused": "yellow",
+    "Degraded": "red",
+    "Progressing": "cyan",
+    "Abort": "red",
+    "Error": "red",
+}
+
+
+# ============================================================================
+# EcosystemScreen
+# ============================================================================
+
+
+class EcosystemScreen(BaseScreen[None]):
+    """Dashboard for ecosystem tools: ArgoCD, Flux, Cert-Manager, Rollouts.
+
+    Presents a 2x2 grid of DataTables, each showing resources from one
+    ecosystem tool. Panels load independently and gracefully handle
+    missing CRDs.
+
+    Args:
+        client: Kubernetes API client instance.
+    """
+
+    BINDINGS = [
+        ("escape", "back", "Back"),
+        ("r", "refresh", "Refresh"),
+        ("1", "focus_argocd", "ArgoCD"),
+        ("2", "focus_flux", "Flux"),
+        ("3", "focus_certs", "Certs"),
+        ("4", "focus_rollouts", "Rollouts"),
+    ]
+
+    def __init__(self, client: KubernetesClient) -> None:
+        """Initialize the ecosystem screen.
+
+        Args:
+            client: Kubernetes API client for cluster communication.
+        """
+        super().__init__()
+        self._client = client
+        self.__argocd_mgr: ArgoCDManager | None = None
+        self.__flux_mgr: FluxManager | None = None
+        self.__cert_mgr: CertManagerManager | None = None
+        self.__rollouts_mgr: RolloutsManager | None = None
+
+    # =========================================================================
+    # Lazy Manager Properties
+    # =========================================================================
+
+    @property
+    def _argocd_mgr(self) -> ArgoCDManager:
+        """Lazy-loaded ArgoCD manager instance."""
+        if self.__argocd_mgr is None:
+            from system_operations_manager.services.kubernetes.argocd_manager import (
+                ArgoCDManager,
+            )
+
+            self.__argocd_mgr = ArgoCDManager(self._client)
+        return self.__argocd_mgr
+
+    @property
+    def _flux_mgr(self) -> FluxManager:
+        """Lazy-loaded Flux manager instance."""
+        if self.__flux_mgr is None:
+            from system_operations_manager.services.kubernetes.flux_manager import (
+                FluxManager,
+            )
+
+            self.__flux_mgr = FluxManager(self._client)
+        return self.__flux_mgr
+
+    @property
+    def _cert_mgr(self) -> CertManagerManager:
+        """Lazy-loaded Cert-Manager manager instance."""
+        if self.__cert_mgr is None:
+            from system_operations_manager.services.kubernetes.certmanager_manager import (
+                CertManagerManager,
+            )
+
+            self.__cert_mgr = CertManagerManager(self._client)
+        return self.__cert_mgr
+
+    @property
+    def _rollouts_mgr(self) -> RolloutsManager:
+        """Lazy-loaded Argo Rollouts manager instance."""
+        if self.__rollouts_mgr is None:
+            from system_operations_manager.services.kubernetes.rollouts_manager import (
+                RolloutsManager,
+            )
+
+            self.__rollouts_mgr = RolloutsManager(self._client)
+        return self.__rollouts_mgr
+
+    # =========================================================================
+    # Layout
+    # =========================================================================
+
+    def compose(self) -> ComposeResult:
+        """Compose the ecosystem dashboard layout."""
+        yield Container(
+            Label(
+                "[bold]Ecosystem Tools Overview[/bold]",
+                id="ecosystem-header",
+            ),
+            Horizontal(
+                Container(
+                    Label(
+                        "[bold]ArgoCD Applications[/bold]",
+                        classes="panel-title",
+                    ),
+                    DataTable(id="argocd-table"),
+                    id="argocd-panel",
+                    classes="ecosystem-panel",
+                ),
+                Container(
+                    Label(
+                        "[bold]Flux Resources[/bold]",
+                        classes="panel-title",
+                    ),
+                    DataTable(id="flux-table"),
+                    id="flux-panel",
+                    classes="ecosystem-panel",
+                ),
+                id="ecosystem-top-row",
+            ),
+            Horizontal(
+                Container(
+                    Label(
+                        "[bold]Cert-Manager Certificates[/bold]",
+                        classes="panel-title",
+                    ),
+                    DataTable(id="cert-table"),
+                    id="cert-panel",
+                    classes="ecosystem-panel",
+                ),
+                Container(
+                    Label(
+                        "[bold]Argo Rollouts[/bold]",
+                        classes="panel-title",
+                    ),
+                    DataTable(id="rollouts-table"),
+                    id="rollouts-panel",
+                    classes="ecosystem-panel",
+                ),
+                id="ecosystem-bottom-row",
+            ),
+            RefreshTimer(interval=30),
+            id="ecosystem-container",
+        )
+
+    def on_mount(self) -> None:
+        """Configure tables and load initial data."""
+        self._setup_tables()
+        self._refresh_all()
+
+    # =========================================================================
+    # Table Setup
+    # =========================================================================
+
+    def _setup_tables(self) -> None:
+        """Configure DataTable columns for all four panels."""
+        for table_id, columns in [
+            ("argocd-table", ARGOCD_COLUMNS),
+            ("flux-table", FLUX_COLUMNS),
+            ("cert-table", CERT_COLUMNS),
+            ("rollouts-table", ROLLOUT_COLUMNS),
+        ]:
+            table = self.query_one(f"#{table_id}", DataTable)
+            table.cursor_type = "row"
+            table.zebra_stripes = True
+            for col_label, width in columns:
+                table.add_column(col_label, width=width)
+
+    # =========================================================================
+    # Refresh
+    # =========================================================================
+
+    def _refresh_all(self) -> None:
+        """Trigger background data loading for all panels."""
+        self._load_argocd()
+        self._load_flux()
+        self._load_certs()
+        self._load_rollouts()
+
+    @on(RefreshTimer.RefreshTriggered)
+    def handle_auto_refresh(self, event: RefreshTimer.RefreshTriggered) -> None:
+        """Handle auto-refresh timer firing."""
+        self._refresh_all()
+
+    @on(RefreshTimer.IntervalChanged)
+    def handle_interval_changed(self, event: RefreshTimer.IntervalChanged) -> None:
+        """Handle refresh interval change."""
+        self.notify_user(f"Refresh interval: {event.interval}s")
+
+    # =========================================================================
+    # Panel Loaders
+    # =========================================================================
+
+    @work(thread=True)
+    def _load_argocd(self) -> None:
+        """Load ArgoCD application data in a background thread."""
+        table = self.query_one("#argocd-table", DataTable)
+        self.app.call_from_thread(table.clear)
+        try:
+            apps = self._argocd_mgr.list_applications()
+            if not apps:
+                self.app.call_from_thread(
+                    self._add_info_row,
+                    "argocd-table",
+                    "No applications found",
+                    len(ARGOCD_COLUMNS),
+                )
+                return
+            for app in apps:
+                self.app.call_from_thread(
+                    table.add_row,
+                    app.name,
+                    app.namespace or "",
+                    app.project,
+                    _colorize(app.sync_status, SYNC_STATUS_COLORS),
+                    _colorize(app.health_status, HEALTH_STATUS_COLORS),
+                    app.repo_url,
+                )
+        except KubernetesNotFoundError:
+            logger.debug("argocd_not_installed")
+            self.app.call_from_thread(
+                self._add_info_row,
+                "argocd-table",
+                "ArgoCD not installed",
+                len(ARGOCD_COLUMNS),
+            )
+        except Exception as e:
+            logger.warning("argocd_load_error", error=str(e))
+            self.app.call_from_thread(
+                self._add_info_row,
+                "argocd-table",
+                f"Error: {e}",
+                len(ARGOCD_COLUMNS),
+            )
+
+    @work(thread=True)
+    def _load_flux(self) -> None:
+        """Load Flux CD resource data in a background thread."""
+        table = self.query_one("#flux-table", DataTable)
+        self.app.call_from_thread(table.clear)
+        try:
+            rows: list[tuple[str, ...]] = []
+
+            git_repos = self._flux_mgr.list_git_repositories()
+            for repo in git_repos:
+                rows.append(
+                    (
+                        repo.name,
+                        repo.namespace or "",
+                        "GitRepo",
+                        _ready_indicator(repo.ready),
+                        _flux_status(repo.ready, repo.reconciling, repo.suspended),
+                        repo.artifact_revision or "-",
+                    )
+                )
+
+            kustomizations = self._flux_mgr.list_kustomizations()
+            for ks in kustomizations:
+                rows.append(
+                    (
+                        ks.name,
+                        ks.namespace or "",
+                        "Kustomization",
+                        _ready_indicator(ks.ready),
+                        _flux_status(ks.ready, ks.reconciling, ks.suspended),
+                        ks.last_applied_revision or "-",
+                    )
+                )
+
+            helm_releases = self._flux_mgr.list_helm_releases()
+            for hr in helm_releases:
+                rows.append(
+                    (
+                        hr.name,
+                        hr.namespace or "",
+                        "HelmRelease",
+                        _ready_indicator(hr.ready),
+                        _flux_status(hr.ready, hr.reconciling, hr.suspended),
+                        hr.chart_name,
+                    )
+                )
+
+            if not rows:
+                self.app.call_from_thread(
+                    self._add_info_row,
+                    "flux-table",
+                    "No Flux resources found",
+                    len(FLUX_COLUMNS),
+                )
+                return
+            for row in rows:
+                self.app.call_from_thread(table.add_row, *row)
+        except KubernetesNotFoundError:
+            logger.debug("flux_not_installed")
+            self.app.call_from_thread(
+                self._add_info_row,
+                "flux-table",
+                "Flux CD not installed",
+                len(FLUX_COLUMNS),
+            )
+        except Exception as e:
+            logger.warning("flux_load_error", error=str(e))
+            self.app.call_from_thread(
+                self._add_info_row,
+                "flux-table",
+                f"Error: {e}",
+                len(FLUX_COLUMNS),
+            )
+
+    @work(thread=True)
+    def _load_certs(self) -> None:
+        """Load Cert-Manager certificate data in a background thread."""
+        table = self.query_one("#cert-table", DataTable)
+        self.app.call_from_thread(table.clear)
+        try:
+            certs = self._cert_mgr.list_certificates()
+            if not certs:
+                self.app.call_from_thread(
+                    self._add_info_row,
+                    "cert-table",
+                    "No certificates found",
+                    len(CERT_COLUMNS),
+                )
+                return
+            for cert in certs:
+                dns_display = ", ".join(cert.dns_names[:3])
+                if len(cert.dns_names) > 3:
+                    dns_display += f" (+{len(cert.dns_names) - 3})"
+                self.app.call_from_thread(
+                    table.add_row,
+                    cert.name,
+                    cert.namespace or "",
+                    _ready_indicator(cert.ready),
+                    cert.not_after or "N/A",
+                    cert.issuer_name,
+                    dns_display,
+                )
+        except KubernetesNotFoundError:
+            logger.debug("certmanager_not_installed")
+            self.app.call_from_thread(
+                self._add_info_row,
+                "cert-table",
+                "Cert-Manager not installed",
+                len(CERT_COLUMNS),
+            )
+        except Exception as e:
+            logger.warning("certmanager_load_error", error=str(e))
+            self.app.call_from_thread(
+                self._add_info_row,
+                "cert-table",
+                f"Error: {e}",
+                len(CERT_COLUMNS),
+            )
+
+    @work(thread=True)
+    def _load_rollouts(self) -> None:
+        """Load Argo Rollouts data in a background thread."""
+        table = self.query_one("#rollouts-table", DataTable)
+        self.app.call_from_thread(table.clear)
+        try:
+            rollouts = self._rollouts_mgr.list_rollouts()
+            if not rollouts:
+                self.app.call_from_thread(
+                    self._add_info_row,
+                    "rollouts-table",
+                    "No rollouts found",
+                    len(ROLLOUT_COLUMNS),
+                )
+                return
+            for ro in rollouts:
+                ready_str = f"{ro.ready_replicas}/{ro.replicas}"
+                weight_str = f"{ro.canary_weight}%" if ro.strategy == "canary" else "-"
+                self.app.call_from_thread(
+                    table.add_row,
+                    ro.name,
+                    ro.namespace or "",
+                    ro.strategy,
+                    _colorize(ro.phase, PHASE_COLORS),
+                    ready_str,
+                    weight_str,
+                )
+        except KubernetesNotFoundError:
+            logger.debug("rollouts_not_installed")
+            self.app.call_from_thread(
+                self._add_info_row,
+                "rollouts-table",
+                "Argo Rollouts not installed",
+                len(ROLLOUT_COLUMNS),
+            )
+        except Exception as e:
+            logger.warning("rollouts_load_error", error=str(e))
+            self.app.call_from_thread(
+                self._add_info_row,
+                "rollouts-table",
+                f"Error: {e}",
+                len(ROLLOUT_COLUMNS),
+            )
+
+    # =========================================================================
+    # Helpers
+    # =========================================================================
+
+    def _add_info_row(self, table_id: str, message: str, col_count: int) -> None:
+        """Add a single informational row spanning the first column.
+
+        Args:
+            table_id: ID of the DataTable (without '#').
+            message: Message text to display.
+            col_count: Number of columns in the table.
+        """
+        table = self.query_one(f"#{table_id}", DataTable)
+        cells = [f"[dim]{message}[/dim]"] + [""] * (col_count - 1)
+        table.add_row(*cells)
+
+    # =========================================================================
+    # Keyboard Actions
+    # =========================================================================
+
+    def action_back(self) -> None:
+        """Navigate back to previous screen."""
+        self.go_back()
+
+    def action_refresh(self) -> None:
+        """Manually refresh all panels."""
+        self._refresh_all()
+
+    def action_focus_argocd(self) -> None:
+        """Focus the ArgoCD panel."""
+        self.query_one("#argocd-table", DataTable).focus()
+
+    def action_focus_flux(self) -> None:
+        """Focus the Flux panel."""
+        self.query_one("#flux-table", DataTable).focus()
+
+    def action_focus_certs(self) -> None:
+        """Focus the Cert-Manager panel."""
+        self.query_one("#cert-table", DataTable).focus()
+
+    def action_focus_rollouts(self) -> None:
+        """Focus the Argo Rollouts panel."""
+        self.query_one("#rollouts-table", DataTable).focus()
+
+
+# ============================================================================
+# Module-level Helpers
+# ============================================================================
+
+
+def _colorize(text: str, color_map: dict[str, str]) -> str:
+    """Apply Rich markup color to text based on a color map.
+
+    Args:
+        text: The text to colorize.
+        color_map: Mapping of text values to Rich color names.
+
+    Returns:
+        Rich-markup formatted string, or the original text if no mapping found.
+    """
+    color = color_map.get(text)
+    if color:
+        return f"[{color}]{text}[/{color}]"
+    return text
+
+
+def _ready_indicator(ready: bool) -> str:
+    """Return a colorized ready/not-ready indicator.
+
+    Args:
+        ready: Whether the resource is ready.
+
+    Returns:
+        Rich-markup formatted indicator string.
+    """
+    if ready:
+        return "[green]Yes[/green]"
+    return "[red]No[/red]"
+
+
+def _flux_status(ready: bool, reconciling: bool, suspended: bool) -> str:
+    """Derive a human-readable status string for a Flux resource.
+
+    Args:
+        ready: Whether the resource is ready.
+        reconciling: Whether the resource is reconciling.
+        suspended: Whether the resource is suspended.
+
+    Returns:
+        Colorized status string.
+    """
+    if suspended:
+        return "[dim]Suspended[/dim]"
+    if reconciling:
+        return "[cyan]Reconciling[/cyan]"
+    if ready:
+        return "[green]Ready[/green]"
+    return "[red]Not Ready[/red]"

--- a/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
+++ b/src/system_operations_manager/tui/apps/kubernetes/styles.tcss
@@ -300,3 +300,38 @@ DataTable > .datatable--cursor {
     padding: 1;
     scrollbar-gutter: stable;
 }
+
+/* ============================================ */
+/* Ecosystem Screen Styles                      */
+/* ============================================ */
+
+#ecosystem-container {
+    padding: 1;
+}
+
+#ecosystem-header {
+    height: 3;
+    dock: top;
+    padding: 0 1;
+    text-style: bold;
+}
+
+#ecosystem-top-row,
+#ecosystem-bottom-row {
+    height: 1fr;
+    padding: 0;
+}
+
+.ecosystem-panel {
+    width: 50%;
+    border: solid $primary;
+    padding: 1;
+    margin: 0 1 1 0;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.ecosystem-panel DataTable {
+    height: auto;
+    max-height: 100%;
+}

--- a/tests/unit/tui/apps/kubernetes/test_app.py
+++ b/tests/unit/tui/apps/kubernetes/test_app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from textual.binding import Binding
 
 from system_operations_manager.tui.apps.kubernetes.app import (
     CLUSTER_SCOPED_TYPES,
@@ -141,6 +142,12 @@ class TestKubernetesAppInit:
         """App defines keyboard bindings."""
         app = KubernetesApp(client=mock_client)
         assert len(app.BINDINGS) > 0
+
+    @pytest.mark.unit
+    def test_app_bindings_include_ecosystem(self) -> None:
+        """App bindings include 'e' for ecosystem view."""
+        binding_keys = [b.key if isinstance(b, Binding) else b[0] for b in KubernetesApp.BINDINGS]
+        assert "e" in binding_keys
 
 
 # ============================================================================

--- a/tests/unit/tui/apps/kubernetes/test_ecosystem_screen.py
+++ b/tests/unit/tui/apps/kubernetes/test_ecosystem_screen.py
@@ -1,0 +1,253 @@
+"""Unit tests for Kubernetes TUI ecosystem screen.
+
+Tests EcosystemScreen bindings, constants, color maps,
+constructor, and default state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.binding import Binding
+
+from system_operations_manager.tui.apps.kubernetes.ecosystem_screen import (
+    ARGOCD_COLUMNS,
+    CERT_COLUMNS,
+    FLUX_COLUMNS,
+    HEALTH_STATUS_COLORS,
+    PHASE_COLORS,
+    ROLLOUT_COLUMNS,
+    SYNC_STATUS_COLORS,
+    EcosystemScreen,
+    _colorize,
+    _flux_status,
+    _ready_indicator,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture()
+def mock_k8s_client() -> MagicMock:
+    """Create a mock KubernetesClient."""
+    return MagicMock()
+
+
+# ============================================================================
+# Binding Tests
+# ============================================================================
+
+
+def _binding_keys() -> list[str]:
+    """Extract binding key strings from EcosystemScreen."""
+    return [b.key if isinstance(b, Binding) else b[0] for b in EcosystemScreen.BINDINGS]
+
+
+class TestEcosystemBindings:
+    """Tests for EcosystemScreen key bindings."""
+
+    @pytest.mark.unit
+    def test_has_bindings(self) -> None:
+        """Screen defines bindings."""
+        assert len(EcosystemScreen.BINDINGS) > 0
+
+    @pytest.mark.unit
+    def test_escape_binding(self) -> None:
+        """Escape navigates back."""
+        assert "escape" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_refresh_binding(self) -> None:
+        """'r' triggers manual refresh."""
+        assert "r" in _binding_keys()
+
+    @pytest.mark.unit
+    def test_panel_focus_bindings(self) -> None:
+        """Number keys 1-4 focus individual panels."""
+        keys = _binding_keys()
+        assert "1" in keys
+        assert "2" in keys
+        assert "3" in keys
+        assert "4" in keys
+
+
+# ============================================================================
+# Column Constant Tests
+# ============================================================================
+
+
+class TestColumnConstants:
+    """Tests for column definition constants."""
+
+    @pytest.mark.unit
+    def test_argocd_columns_non_empty(self) -> None:
+        """ArgoCD column list is non-empty."""
+        assert len(ARGOCD_COLUMNS) > 0
+
+    @pytest.mark.unit
+    def test_flux_columns_non_empty(self) -> None:
+        """Flux column list is non-empty."""
+        assert len(FLUX_COLUMNS) > 0
+
+    @pytest.mark.unit
+    def test_cert_columns_non_empty(self) -> None:
+        """Cert-Manager column list is non-empty."""
+        assert len(CERT_COLUMNS) > 0
+
+    @pytest.mark.unit
+    def test_rollout_columns_non_empty(self) -> None:
+        """Rollout column list is non-empty."""
+        assert len(ROLLOUT_COLUMNS) > 0
+
+    @pytest.mark.unit
+    def test_columns_are_tuples_of_str_int(self) -> None:
+        """All column definitions are (str, int) tuples."""
+        for columns in [ARGOCD_COLUMNS, FLUX_COLUMNS, CERT_COLUMNS, ROLLOUT_COLUMNS]:
+            for col_label, col_width in columns:
+                assert isinstance(col_label, str)
+                assert isinstance(col_width, int)
+                assert col_width > 0
+
+
+# ============================================================================
+# Color Map Tests
+# ============================================================================
+
+
+class TestColorMaps:
+    """Tests for status color maps."""
+
+    @pytest.mark.unit
+    def test_sync_status_colors_non_empty(self) -> None:
+        """Sync status color map is non-empty."""
+        assert len(SYNC_STATUS_COLORS) > 0
+
+    @pytest.mark.unit
+    def test_health_status_colors_non_empty(self) -> None:
+        """Health status color map is non-empty."""
+        assert len(HEALTH_STATUS_COLORS) > 0
+
+    @pytest.mark.unit
+    def test_phase_colors_non_empty(self) -> None:
+        """Phase color map is non-empty."""
+        assert len(PHASE_COLORS) > 0
+
+    @pytest.mark.unit
+    def test_color_maps_have_string_values(self) -> None:
+        """All color maps map strings to strings."""
+        for color_map in [SYNC_STATUS_COLORS, HEALTH_STATUS_COLORS, PHASE_COLORS]:
+            for key, value in color_map.items():
+                assert isinstance(key, str)
+                assert isinstance(value, str)
+
+    @pytest.mark.unit
+    def test_sync_colors_cover_common_statuses(self) -> None:
+        """Sync color map covers Synced and OutOfSync."""
+        assert "Synced" in SYNC_STATUS_COLORS
+        assert "OutOfSync" in SYNC_STATUS_COLORS
+
+    @pytest.mark.unit
+    def test_health_colors_cover_common_statuses(self) -> None:
+        """Health color map covers Healthy, Degraded, Progressing."""
+        assert "Healthy" in HEALTH_STATUS_COLORS
+        assert "Degraded" in HEALTH_STATUS_COLORS
+        assert "Progressing" in HEALTH_STATUS_COLORS
+
+    @pytest.mark.unit
+    def test_phase_colors_cover_common_phases(self) -> None:
+        """Phase color map covers Healthy, Paused, Degraded."""
+        assert "Healthy" in PHASE_COLORS
+        assert "Paused" in PHASE_COLORS
+        assert "Degraded" in PHASE_COLORS
+
+
+# ============================================================================
+# Constructor Tests
+# ============================================================================
+
+
+class TestEcosystemConstructor:
+    """Tests for EcosystemScreen initialization."""
+
+    @pytest.mark.unit
+    def test_stores_client(self, mock_k8s_client: MagicMock) -> None:
+        """Constructor stores the K8s client."""
+        screen = EcosystemScreen(client=mock_k8s_client)
+        assert screen._client is mock_k8s_client
+
+    @pytest.mark.unit
+    def test_lazy_managers_start_none(self, mock_k8s_client: MagicMock) -> None:
+        """Lazy manager backing fields start as None."""
+        screen = EcosystemScreen(client=mock_k8s_client)
+        assert screen._EcosystemScreen__argocd_mgr is None
+        assert screen._EcosystemScreen__flux_mgr is None
+        assert screen._EcosystemScreen__cert_mgr is None
+        assert screen._EcosystemScreen__rollouts_mgr is None
+
+
+# ============================================================================
+# Helper Function Tests
+# ============================================================================
+
+
+class TestHelperFunctions:
+    """Tests for module-level helper functions."""
+
+    @pytest.mark.unit
+    def test_colorize_known_key(self) -> None:
+        """_colorize applies color for known key."""
+        result = _colorize("Synced", SYNC_STATUS_COLORS)
+        assert result == "[green]Synced[/green]"
+
+    @pytest.mark.unit
+    def test_colorize_unknown_key(self) -> None:
+        """_colorize returns plain text for unknown key."""
+        result = _colorize("CustomStatus", SYNC_STATUS_COLORS)
+        assert result == "CustomStatus"
+
+    @pytest.mark.unit
+    def test_ready_indicator_true(self) -> None:
+        """_ready_indicator returns green Yes for True."""
+        result = _ready_indicator(True)
+        assert "Yes" in result
+        assert "green" in result
+
+    @pytest.mark.unit
+    def test_ready_indicator_false(self) -> None:
+        """_ready_indicator returns red No for False."""
+        result = _ready_indicator(False)
+        assert "No" in result
+        assert "red" in result
+
+    @pytest.mark.unit
+    def test_flux_status_suspended(self) -> None:
+        """_flux_status returns Suspended when suspended."""
+        result = _flux_status(ready=False, reconciling=False, suspended=True)
+        assert "Suspended" in result
+
+    @pytest.mark.unit
+    def test_flux_status_reconciling(self) -> None:
+        """_flux_status returns Reconciling when reconciling."""
+        result = _flux_status(ready=False, reconciling=True, suspended=False)
+        assert "Reconciling" in result
+
+    @pytest.mark.unit
+    def test_flux_status_ready(self) -> None:
+        """_flux_status returns Ready when ready."""
+        result = _flux_status(ready=True, reconciling=False, suspended=False)
+        assert "Ready" in result
+
+    @pytest.mark.unit
+    def test_flux_status_not_ready(self) -> None:
+        """_flux_status returns Not Ready when none of the above."""
+        result = _flux_status(ready=False, reconciling=False, suspended=False)
+        assert "Not Ready" in result
+
+    @pytest.mark.unit
+    def test_flux_status_suspended_takes_priority(self) -> None:
+        """Suspended takes priority over ready and reconciling."""
+        result = _flux_status(ready=True, reconciling=True, suspended=True)
+        assert "Suspended" in result


### PR DESCRIPTION
## Summary
- Add `EcosystemScreen` with 2x2 dashboard showing ArgoCD, Flux CD, Cert-Manager, and Argo Rollouts status
- Each panel loads independently via `@work(thread=True)` with graceful "not installed" handling for missing CRDs
- Wire `e` binding at app level to open the ecosystem overview

## Task
Closes beads task `system-operations-manager-10r`: TUI ecosystem tools view

## Changes
- **Created** `src/system_operations_manager/tui/apps/kubernetes/ecosystem_screen.py` - EcosystemScreen with 4 lazy-loaded managers, column/color constants, background workers
- **Modified** `src/system_operations_manager/tui/apps/kubernetes/app.py` - Add `e` binding, `action_ecosystem()`, import, help text
- **Modified** `src/system_operations_manager/tui/apps/kubernetes/styles.tcss` - Add ecosystem screen CSS section
- **Created** `tests/unit/tui/apps/kubernetes/test_ecosystem_screen.py` - Binding, constant, color map, constructor, helper function tests
- **Modified** `tests/unit/tui/apps/kubernetes/test_app.py` - Add ecosystem binding test

## Validation
- [x] All 216 K8s TUI tests pass
- [x] All 3615 tests pass (74 skipped)
- [x] Lint clean
- [x] Format clean
- [x] All pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)