### PR TITLE
feat(integrations): add CORS preflight OPTIONS to routes

### DIFF
--- a/src/system_operations_manager/integrations/kong/models/service_registry.py
+++ b/src/system_operations_manager/integrations/kong/models/service_registry.py
@@ -40,6 +40,7 @@ class ServiceRegistryEntry(BaseModel):
         openapi_spec: Path to OpenAPI specification file.
         path_prefix: Prefix to add to all route paths.
         strip_path: Whether to strip matched path when proxying.
+        include_options_method: Include OPTIONS in route methods for CORS preflight.
     """
 
     model_config = ConfigDict(
@@ -76,6 +77,10 @@ class ServiceRegistryEntry(BaseModel):
     strip_path: bool = Field(
         default=False,
         description="Strip matched path when proxying",
+    )
+    include_options_method: bool = Field(
+        default=False,
+        description="Include OPTIONS method on all routes for CORS preflight support",
     )
 
     @field_validator("name")

--- a/src/system_operations_manager/plugins/kong/commands/registry.py
+++ b/src/system_operations_manager/plugins/kong/commands/registry.py
@@ -191,6 +191,13 @@ def register_registry_commands(
             bool,
             typer.Option("--strip-path/--no-strip-path", help="Strip path when proxying"),
         ] = False,
+        include_options_method: Annotated[
+            bool,
+            typer.Option(
+                "--include-options/--no-include-options",
+                help="Include OPTIONS method on all routes for CORS preflight",
+            ),
+        ] = False,
     ) -> None:
         """Add a service to the registry.
 
@@ -198,6 +205,7 @@ def register_registry_commands(
             ops kong registry add auth-service --host auth.local --port 8080
             ops kong registry add api --host api.local --tag prod --tag api
             ops kong registry add users --host users.local --openapi-spec ./openapi.yaml
+            ops kong registry add api --host api.local --spec ./openapi.yaml --include-options
         """
         try:
             entry = ServiceRegistryEntry(
@@ -210,6 +218,7 @@ def register_registry_commands(
                 openapi_spec=openapi_spec,
                 path_prefix=path_prefix,
                 strip_path=strip_path,
+                include_options_method=include_options_method,
             )
         except PydanticValidationError as e:
             console.print("[red]Error:[/red] Invalid service configuration")
@@ -253,6 +262,13 @@ def register_registry_commands(
             bool | None,
             typer.Option("--strip-path/--no-strip-path", help="Strip path when proxying"),
         ] = None,
+        include_options_method: Annotated[
+            bool | None,
+            typer.Option(
+                "--include-options/--no-include-options",
+                help="Include OPTIONS method on all routes for CORS preflight",
+            ),
+        ] = None,
     ) -> None:
         """Edit an existing service in the registry.
 
@@ -262,7 +278,7 @@ def register_registry_commands(
             ops kong registry edit auth-service --port 9090
             ops kong registry edit auth-service --host new-host.local --port 8080
             ops kong registry edit auth-service --no-strip-path
-            ops kong registry edit auth-service --tag prod --tag api
+            ops kong registry edit auth-service --include-options
         """
         manager = get_registry_manager()
         existing = manager.get_service(name)
@@ -290,6 +306,8 @@ def register_registry_commands(
             updated_data["path_prefix"] = path_prefix
         if strip_path is not None:
             updated_data["strip_path"] = strip_path
+        if include_options_method is not None:
+            updated_data["include_options_method"] = include_options_method
 
         try:
             updated_entry = ServiceRegistryEntry(**updated_data)

--- a/src/system_operations_manager/services/kong/openapi_sync_manager.py
+++ b/src/system_operations_manager/services/kong/openapi_sync_manager.py
@@ -283,6 +283,7 @@ class OpenAPISyncManager:
         *,
         path_prefix: str | None = None,
         strip_path: bool = True,
+        include_options_method: bool = False,
     ) -> list[RouteMapping]:
         """Generate Kong route mappings from OpenAPI spec.
 
@@ -294,6 +295,9 @@ class OpenAPISyncManager:
             service_name: Kong service name (used for route naming and tagging).
             path_prefix: Optional prefix to add to all paths.
             strip_path: Whether routes should strip the matched path.
+            include_options_method: Include OPTIONS in route methods for CORS
+                preflight support. When True, OPTIONS is added to every route's
+                methods list so Kong can match preflight requests.
 
         Returns:
             List of route mappings.
@@ -328,6 +332,8 @@ class OpenAPISyncManager:
 
             # Collect methods and tags
             methods = sorted({op.method for op in operations})
+            if include_options_method and "OPTIONS" not in methods:
+                methods = sorted(set(methods) | {"OPTIONS"})
             operation_tags: set[str] = set()
             operation_ids: list[str] = []
 

--- a/src/system_operations_manager/services/kong/registry_manager.py
+++ b/src/system_operations_manager/services/kong/registry_manager.py
@@ -708,6 +708,9 @@ class RegistryManager:
                 if method in methods:
                     http_methods.append(method.upper())
 
+            if entry.include_options_method and "OPTIONS" not in http_methods:
+                http_methods.append("OPTIONS")
+
             if not http_methods:
                 continue
 
@@ -791,6 +794,7 @@ class RegistryManager:
             entry.name,
             path_prefix=entry.path_prefix,
             strip_path=entry.strip_path,
+            include_options_method=entry.include_options_method,
         )
 
         # Calculate diff and apply

--- a/tests/unit/integrations/kong/models/test_service_registry.py
+++ b/tests/unit/integrations/kong/models/test_service_registry.py
@@ -30,6 +30,7 @@ class TestServiceRegistryEntry:
         assert entry.port == 80
         assert entry.protocol == "http"
         assert entry.enabled is True
+        assert entry.include_options_method is False
         assert entry.openapi_spec is None
 
     @pytest.mark.unit
@@ -50,6 +51,7 @@ class TestServiceRegistryEntry:
             openapi_spec="~/specs/api.yaml",
             path_prefix="/api/v1",
             strip_path=False,
+            include_options_method=True,
         )
 
         assert entry.name == "api-service"
@@ -62,6 +64,7 @@ class TestServiceRegistryEntry:
         assert entry.openapi_spec is not None
         assert entry.path_prefix == "/api/v1"
         assert entry.strip_path is False
+        assert entry.include_options_method is True
 
     @pytest.mark.unit
     def test_name_validation_empty(self) -> None:

--- a/tests/unit/services/kong/test_openapi_sync_manager.py
+++ b/tests/unit/services/kong/test_openapi_sync_manager.py
@@ -255,6 +255,56 @@ class TestRouteMapping:
         assert "Users" in users_route.tags
 
     @pytest.mark.unit
+    def test_generate_route_mappings_with_include_options(
+        self, manager: OpenAPISyncManager
+    ) -> None:
+        """Should include OPTIONS in methods when include_options_method is True."""
+        spec = OpenAPISpec(
+            title="Test API",
+            version="1.0.0",
+            operations=[
+                OpenAPIOperation(
+                    path="/login",
+                    method="POST",
+                    operation_id="login",
+                    tags=["Auth"],
+                ),
+            ],
+            all_tags=["Auth"],
+        )
+
+        mappings = manager.generate_route_mappings(
+            spec, "auth-service", include_options_method=True
+        )
+
+        assert len(mappings) == 1
+        assert set(mappings[0].methods) == {"OPTIONS", "POST"}
+
+    @pytest.mark.unit
+    def test_generate_route_mappings_without_include_options(
+        self, manager: OpenAPISyncManager
+    ) -> None:
+        """Should not include OPTIONS by default."""
+        spec = OpenAPISpec(
+            title="Test API",
+            version="1.0.0",
+            operations=[
+                OpenAPIOperation(
+                    path="/login",
+                    method="POST",
+                    operation_id="login",
+                    tags=["Auth"],
+                ),
+            ],
+            all_tags=["Auth"],
+        )
+
+        mappings = manager.generate_route_mappings(spec, "auth-service")
+
+        assert len(mappings) == 1
+        assert set(mappings[0].methods) == {"POST"}
+
+    @pytest.mark.unit
     def test_route_naming_with_operation_id(self, manager: OpenAPISyncManager) -> None:
         """Should use operationId for route naming."""
         spec = OpenAPISpec(


### PR DESCRIPTION
## Summary

- Adds `include_options_method` field to `ServiceRegistryEntry` that injects `OPTIONS` into every route's methods list during OpenAPI sync
- Fixes CORS preflight 404s caused by Kong evaluating route matching before plugins — routes from OpenAPI specs never included OPTIONS, so the CORS plugin couldn't fire
- Threads the new field through both Gateway and Konnect sync paths, plus CLI `registry add`/`edit` commands

## Usage

```yaml
# ~/.config/ops/kong/services.yaml
services:
  - name: auth-service
    host: auth-service.auth-service.svc.cluster.local
    openapi_spec: ~/repos/auth-service/openapi.yaml
    path_prefix: /api/v1/auth
    include_options_method: true
```

## Test plan

- [x] Unit tests pass (`pytest tests/unit/services/kong/test_openapi_sync_manager.py` — 57 passed)
- [x] Model tests pass (`pytest tests/unit/integrations/kong/models/test_service_registry.py` — 29 passed)
- [x] Registry command tests pass (`pytest tests/unit/plugins/kong/commands/test_registry.py` — 65 passed)
- [x] mypy passes on all changed files
- [x] Verified OPTIONS present on all 100 routes via Kong Admin API after deploy
- [x] Confirmed browser CORS preflight succeeds for auth-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)